### PR TITLE
Quest status show up in target list

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -370,6 +370,7 @@
 			EnableTimer("tim_init_plugin", false)
 			load_saved_table_data()
 			send_gmcp_packet("config noexp")
+			send_gmcp_packet("request quest")
 		end
 	end
 
@@ -1531,6 +1532,7 @@ end
 			SetVariable("mcvar_qt_areaName", "")
 			SetVariable("mcvar_qt_room", "")
 		end
+		xg_draw_window()
 	end
 
 --	[[ "cp info" process path ]]
@@ -3290,6 +3292,48 @@ function goto_number(name, line, wildcards)
 
 	end
 
+	function simulate_quest(name, line, wildcards)
+		local result = {
+			targ = 'a garden snake',
+			area = "Kimr's Farm",
+			room = "Old Farm Lane",
+		}
+		local status = wildcards.status
+		if #status == 0 then status = "status" end
+
+		Note("Simulating quest with status " .. status)
+
+		if status == "start" then
+			result.action = "start"
+		elseif status == "status" then
+			result.action = "status"
+			result.timer = 60
+		elseif status == "killed" then
+			result.action = "killed"
+		elseif status == "comp" then
+			result.action = "comp"
+		elseif status == "fail" then
+			result.action = "fail"
+		elseif status == "reset" then
+			result.action = "reset"
+		elseif status == "ready" then
+			result.action = "ready"
+		elseif status == "timeout" then
+			result.action = "timeout"
+		elseif status == "statkilled" then
+			result.action = "status"
+			result.target = "killed"
+		elseif status == "wait" then
+			result.action = "status"
+			result.wait = 60
+		elseif status == "ready" then
+			result.action = "status"
+			result.status = "ready"
+		end
+
+		quest_status_gmcp(result)
+	end
+
 -- [[ Room notes ]]
 	function room_note_area(name, line, wildcards)
 		if (wildcards.arid == "") then
@@ -3473,8 +3517,10 @@ function goto_number(name, line, wildcards)
 		["cplevel"] = { f="Consolas",				 s=11, 				b=false, 	i=false, 	u=false },
 		["noexp"]	= { f="Consolas",				 s=11, 				b=false, 	i=false, 	u=false }, --noexp tnl
 		["noexp2"]	= { f="Consolas",				 s= 9, 				b=false, 	i=false, 	u=false },
-		["cplist_area"] = { f="Lucida Sans Unicode", s=win_font_size, 	b=false, 	i=false, 	u=false },
-		["cplist_room"] = { f="Segoe", 				 s=win_font_size, 	b=false, 	i=false, 	u=false } }
+		["cplist_area"]  = { f="Lucida Sans Unicode",	s=win_font_size, 	b=false, 	i=false, 	u=false },
+		["cplist_room"]  = { f="Segoe", 				s=win_font_size, 	b=false, 	i=false, 	u=false },
+		["cplist_quest"] = { f="Gadugi",				s=win_font_size+2,	b=true,		i=false, 	u=false },
+	}
 
 	function xg_create_window()
 		if (win_init == false) then
@@ -3725,8 +3771,6 @@ function goto_number(name, line, wildcards)
 		end
 	end
 
-
-
 	function xg_show_target_links()
 		for i,v in ipairs (win_target_hotspots) do
 			WindowDeleteHotspot(win, v)
@@ -3735,12 +3779,16 @@ function goto_number(name, line, wildcards)
 		if (win_state == "min") then return	end
 		local list = main_target_list
 		local font = "cplist_" .. area_room_type
-		local index = 0
 		local resize_tag = 13
 		local targ_list_top = 59
 		local targ_list_bottom = win_height - 5
-		for i,v in ipairs (list) do
-			index = i
+		local font_height = WindowFontInfo (win, font, 1) -- WindowFontInfo (win, font, 4)
+
+		if xg_show_quest_target_link(targ_list_top, resize_tag) then
+			targ_list_top = targ_list_top + win_line_space + 5
+		end
+
+		for index,v in ipairs (list) do
 			if (((index-1) * win_line_space + targ_list_top) > targ_list_bottom) then break end		-- Abort loop if printed item would not be visible.
 			local mob = v.mob .. ((v.is_dead == "yes") and " [Dead]" or "")
 			local ar = v.arid
@@ -3758,21 +3806,15 @@ function goto_number(name, line, wildcards)
 			local qty = ((player_on_gq == "yes") and v.qty .. "* " or "")
 			local link = string.format("%s)  %s%s - %s", index, qty, mob, location)
 			local color = ((index == xcp_index) and "0x0040FF" or convert_color_format(v.color))
-
-			local font_height = WindowFontInfo (win, font, 1) -- WindowFontInfo (win, font, 4)
 			local hs_left = (index < 10) and 13 or 6
 			local hs_top = (targ_list_top + ((index-1) * win_line_space))
-			local hs_right = (hs_left + WindowTextWidth(win, font, link))
+			local hs_right = math.min(hs_left + WindowTextWidth(win, font, link), win_width - 5)
 			local hs_bottom = (hs_top + font_height + 1) --(hs_top + win_line_space )
-
-			if (hs_right > win_width - 5) then hs_right = (win_width - 5) end
 			WindowText(win, font, link, hs_left, hs_top, 0, 0, color, false)
 			if (hs_bottom > win_height - resize_tag) then		-- Prevent list item's hotspot from overlapping with the resize tag
-				if (hs_right > win_width - resize_tag - 5) then
-					hs_right = win_width - resize_tag - 5
-				end
+				hs_right = math.min(hs_right, win_width - resize_tag - 5)
 			end
-			win_target_hotspots[#win_target_hotspots+1] = index
+			table.insert(win_target_hotspots, index)
 			--WindowRectOp (win, 1,
 			--				hs_left-1, hs_top+2, hs_right+2, hs_bottom, 0x000080, 15)
 			WindowAddHotspot(win, index,
@@ -3780,6 +3822,49 @@ function goto_number(name, line, wildcards)
 							"", "", "", "",								-- "mouseover", "cancelmouseover", "mousedown", "cancelmousedown"
 							eventHandler, "", miniwin.cursor_arrow, 0)	-- "mouseup", tooltip, cursor type
 		end
+	end
+
+	function xg_show_quest_target_link(targ_list_top,resize_tag)
+		if not quest_target.qstat or quest_target.qstat == "1" then
+			return false
+		end
+
+		local text
+		local color
+		local font = "cplist_quest"
+		local hs_left, hs_top, hs_right, hs_bottom
+
+		if quest_target.qstat == "0" then
+			text = "You may now quest again"
+			color = 0xFF901E
+		elseif quest_target.qstat == "2" then
+			color = ((full_mob_name == quest_target.mob and xcp_index < 1) and 0x0040FF or 0xE0E0E0)
+			text = string.format("Q) %s - '%s' (%s)", quest_target.mob, quest_target.room, quest_target.arid)
+		elseif quest_target.qstat == "3" then
+			text = "Quest complete! You may turn it in"
+			color = 0x00FC7C
+		else
+			return false
+		end
+
+		hs_left = 13
+		hs_top = targ_list_top
+		hs_right = math.min(hs_left + WindowTextWidth(win, font, text), win_width - 5)
+		hs_bottom = (hs_top + WindowFontInfo(win, font, 1) + 1)
+		if (hs_bottom > win_height - resize_tag) then
+			hs_right = math.min(hs_right, win_width - resize_tag - 5)
+		end
+
+		WindowText(win, font, text, hs_left, hs_top, 0, 0, color, false)
+
+		if quest_target.qstat == "2" then
+			table.insert(win_target_hotspots, 'q')
+			WindowAddHotspot(win, 'q',
+							hs_left-1, hs_top+2, hs_right+2, hs_bottom,
+							"", "", "", "",
+							"win_mouseup_target_quest", "", miniwin.cursor_arrow, 0)
+		end
+		return true
 	end
 
 -- [[ GUI window mouse click functions (buttons, links, etc.) ]]
@@ -3856,6 +3941,11 @@ function goto_number(name, line, wildcards)
 		if (tonumber(hotspot_id) ~= nil) then
 			xcp_arg("", "", {index=hotspot_id})
 		end
+	end
+
+	function win_mouseup_target_quest()
+		target_quest_mob(true)
+		xg_draw_window()
 	end
 
 --	[[ Window dragging / moving ]]
@@ -5615,6 +5705,10 @@ function goto_number(name, line, wildcards)
 
 	<alias	match="^xtest simulate cp(?: (?<type>ar?e?a?|ro?o?m?))?$"
 			script="simulate_cp"
+			enabled="y" regexp="y" sequence="1" ignore_case="y" send_to="12" > </alias>
+
+		<alias	match="^xtest simulate q(?:uest)?(?: (?<status>start|status|killed|comp|fail|reset|ready|timeout|statkilled|wait|ready))?$"
+			script="simulate_quest"
 			enabled="y" regexp="y" sequence="1" ignore_case="y" send_to="12" > </alias>
 
 	<alias	match="^xtest loadroom(?: (?<room_id>\d+))?$"


### PR DESCRIPTION
Puts quest targets or quest status at the top of the campaign target window. When you can take a quest:
![MUSHclient -  Aardwolf  2021-05-31 16 50 02](https://user-images.githubusercontent.com/84752725/120241211-41050980-c230-11eb-8f9e-ffa8012a5861.png)

When you are on a quest, and the quest target is your current focus:
![MUSHclient -  Aardwolf  2021-05-31 16 50 32](https://user-images.githubusercontent.com/84752725/120241237-524e1600-c230-11eb-9449-e391d8a7d3d2.png)

When you are on a quest but the quest target is not your current focus:
![MUSHclient -  Aardwolf  2021-05-31 16 51 08](https://user-images.githubusercontent.com/84752725/120241282-6eea4e00-c230-11eb-8e9e-1074acaa10d9.png)

When you have killed your quest target but not yet turned in the quest:
![MUSHclient -  Aardwolf  2021-05-31 16 51 56](https://user-images.githubusercontent.com/84752725/120241337-89242c00-c230-11eb-89ee-66b2948c7da5.png)

If you're not on a quest and you must wait, it won't show anything about quests in the window.
When a quest is active, you can click on it to bring up information about the quest:
![MUSHclient -  Aardwolf  2021-05-31 16 52 50](https://user-images.githubusercontent.com/84752725/120241389-a48f3700-c230-11eb-9c3e-2c32ed27385d.png)

On the dev side, I added a `xset simulate quest` command, similar to `xset simulate cp`

