### PR TITLE
Only compare the first 30 characters of a name when clearing targets with ht/qw

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -2791,11 +2791,11 @@ end
 		-- change target
 		xcp_index = 0
 		full_mob_name = -1
-		if quest_target.mob and current_room.arid == quest_target.arid and quest_target.mob:lower() == Trim(mob):lower() then
+		if quest_target.mob and current_room.arid == quest_target.arid and quest_target.mob:lower():sub(1, 30) == Trim(mob):lower() then
 			full_mob_name = quest_target.mob
 		else
 			for i, target in ipairs(main_target_list) do
-				if current_room.arid == target.arid and Trim(mob):lower() == target.mob:lower() then
+				if current_room.arid == target.arid and Trim(mob):lower() == target.mob:lower():sub(1, 30) then
 					full_mob_name = target.mob
 					xcp_index = i
 					break


### PR DESCRIPTION
Bug fix for something introduced in https://github.com/AardCrowley/Search-and-Destroy/pull/8/
If the short name of a mob is over 30 characters, than in where their name will be truncated, like "Laurence, archangel of the sword" where you'll see something like
`Laurence, archangel of the swo In the clouds`
Of course, "Laurence, archangel of the sword" does not match "Laurence, archangel of the swo" so doing qw will clear him as a target. This change makes it only compare up to the first 30 characters