### PR TITLE
Tweak xcp retry behaviour

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1888,8 +1888,8 @@ end
 		if (xcp_retry_stat == 2) then
 			DebugNote(string.format("last_kill_index: %i xcp_index_attempt: %i", last_kill_index, xcp_index_attempt))
 			xcp_index = xcp_index_attempt
-			if last_kill_index <= xcp_index_attempt then
-				xcp_index = xcp_index_attempt - 1
+			if last_kill_index < xcp_index_attempt then
+				xcp_index = math.max(1, xcp_index_attempt - 1)
 			end
 			xcp_retry_stat = 0
 			xcp_arg("", "", {index=xcp_index})


### PR DESCRIPTION
Small change to xcp retry behaviour:

Let's say you were chasing the second mob in your list (`xcp 2`) and killed it, then did `xcp 2` after killing it but before the refresh. Before this change, it would go on to target the first thing in the list. With this, it will target the second thing, which had been the third prior to your kill.
