### PR TITLE
Use the mob db to find nowhere/nohunt mobs quickly

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -154,7 +154,7 @@
 	local autoHuntData = {}
 
 -- [[ hunt trick ]]
-	local ht = { index = 1 }
+	local ht = { index = 1, first_target = true }
 
 -- [[ quick where ]]
 	local qw = { index = 1 }
@@ -2399,7 +2399,7 @@ end
 						local func = function() qw_exact(t.kw) end
 						execute_in_area(t.arid, func)
 					elseif (action == "ht") then		-- do hunt trick or quick where after arriving in area.
-						local func = function() Execute("ht " .. t.kw) end
+						local func = function() do_hunt_trick(1, t.kw) end
 						execute_in_area(t.arid, func)
 					elseif (action == "off") then	-- do nothing
 						InfoNote("Xcp action is off - no additional action\n")
@@ -2820,7 +2820,6 @@ end
 	end
 
 	function qw_no_match()	-- responds to "There is no <mob name> around here."
-		DebugNote("Couldn't find ", short_mob_name, " trying to find ", full_mob_name)
 		qw_reset(qw.exact)
 		if type(full_mob_name) == 'string' then
 			lookup_not_found_mob()
@@ -2879,7 +2878,7 @@ end
 
 		table.sort(possible_rooms, sort_rooms_by_count)
 
-		InfoNote("\nMob not found. There are multiple possibilities for this:")
+		InfoNote("\nMob not found. There are multiple possible reasons for this:")
 		InfoNote("  * It might be dead")
 		InfoNote("  * You might be using the wrong keyword (use `xset kw` to update if needed)")
 		InfoNote("  * It might be flagged nowhere")
@@ -2890,7 +2889,7 @@ end
 --	[[ Hunt trick ]]
 	function ht_reset()
 		EnableTriggerGroup("HuntTrick", false)
-		ht = { index = 1 }
+		ht = { index = 1, first_target = true }
 	end
 
 	function ht_noarg()
@@ -2928,6 +2927,7 @@ end
 	function ht_continue()
 		local s = short_mob_name
 		local ix = (ht.index + 1) or 1
+		ht.first_target = false
 		do_hunt_trick(ix, s)
 	end
 
@@ -2939,9 +2939,23 @@ end
 		ht_reset()
 	end
 
+	function ht_fail()
+		local first_target = ht.first_target
+		EnableTriggerGroup("HuntTrick", false)
+		ht_reset()
+
+
+		if first_target and type(full_mob_name) == 'string' then
+			InfoNote("Search and Destroy:  Hunt trick failed. Attempting quick where.")
+			qw_exact()
+		else
+			InfoNote("Search and Destroy:  Hunt trick failed.")
+		end
+	end
+
 	function ht_abort(name, line, wildcards)
 		EnableTriggerGroup("HuntTrick", false)
-		ht = {}
+		ht_reset()
 		InfoNote("Search and Destroy:  Hunt trick cancelled.")
 	end
 
@@ -3585,6 +3599,8 @@ end
 			Simulate("You still have to kill * the spirit of Bakarne (The Empire of Aiighialla)\n")
 			Simulate("You still have to kill * a sinister vandal (The Three Pillars of Diatz)\n") -- noscan
 			Simulate("You still have to kill * a hideously hairy spider (The Temple of Shouggoth)\n") -- nowhere
+			Simulate("You still have to kill * Don Crumble (Zangar's Demonic Grotto)\n") -- nohunt
+			Simulate("You still have to kill * A very large firefly (Kobold Siege Camp)\n") -- nohunt/nowhere
 		else
 			Simulate("You still have to kill * a former court jester (The Labyrinth)\n")
 			Simulate("You still have to kill * the iron golem (Audience Chamber)\n")
@@ -6306,7 +6322,12 @@ end
 		script="ht_continue"
 		enabled="n" regexp="y" sequence="100" > </trigger>
 
-	<trigger match="^No one in this area by the name '\w.+'\.|Not while you are fighting\!|You can't hunt while (?:resting|sitting)\.|You dream about going on a nice hunting trip, with pony rides, and campfires too\.$"
+	<trigger match="^No one in this area by the name '\w.+'\.$"
+		name="trg_hunt_trick_fail" group="HuntTrick"
+		script="ht_fail"
+		enabled="n" regexp="y" sequence="100" keep_evaluating="y" > </trigger>
+
+	<trigger match="^Not while you are fighting\!|You can't hunt while (?:resting|sitting)\.|You dream about going on a nice hunting trip, with pony rides, and campfires too\.$"
 		name="trg_hunt_trick_abort" group="HuntTrick"
 		script="ht_abort"
 		enabled="n" regexp="y" sequence="100" keep_evaluating="y" > </trigger>

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -2692,14 +2692,10 @@ end
 	end
 
 --	[[ quick where ]]
-	function qw_reset(bool)
+	function qw_reset(exact)
 		EnableTrigger("trg_quick_where_match", false)
 		EnableTrigger("trg_quick_where_no_match", false)
-		if (bool == true) then
-			qw = { index = 1, exact = true }
-		else
-			qw = { index = 1, exact = false }
-		end
+		qw = { index = 1, exact = exact }
 	end
 
 	function qw_noarg()
@@ -2824,7 +2820,71 @@ end
 	end
 
 	function qw_no_match()	-- responds to "There is no <mob name> around here."
+		DebugNote("Couldn't find ", short_mob_name, " trying to find ", full_mob_name)
 		qw_reset(qw.exact)
+		if type(full_mob_name) == 'string' then
+			lookup_not_found_mob()
+		end
+	end
+
+	function lookup_not_found_mob()
+		local full_name = full_mob_name:lower()
+		local search_name = short_mob_name -- needed?
+		local arid = current_room.arid
+		local found = false
+		local query = string.format("SELECT room, roomid, count FROM mobs WHERE zone = %s AND mob = %s;",
+			fixsql(arid), fixsql(full_name))
+
+		local db = assert(sqlite3.open(snd_db_file))
+		local possible_rooms = {}
+		local roomids= {}
+		local total_count = 0
+
+		for row in db:nrows(query) do
+			found = true
+			table.insert(possible_rooms, {
+				rmid = row.roomid,
+				name = row.room,
+				arid = arid,
+				count = row.count,
+			})
+			total_count = total_count + row.count
+			table.insert(roomids, row.roomid)
+		end
+		db:close_vm()
+
+		if not found then
+			return
+		end
+
+		query = string.format("SELECT uid, notes FROM bookmarks WHERE uid in (%s);", table.concat(roomids, ","))
+		db = assert(sqlite3.open(mapper_db_file))
+
+		for row in db:nrows(query) do
+			for i, room in ipairs(possible_rooms) do
+				if tostring(room.rmid) == row.uid then
+					room.notes = row.notes
+					break
+				end
+			end
+		end
+
+		for i, room in ipairs(possible_rooms) do
+			if total_count > 0 then
+				room.percentage = (room.count / total_count)
+			else
+				room.percentage = 0
+			end
+		end
+
+		table.sort(possible_rooms, sort_rooms_by_count)
+
+		InfoNote("\nMob not found. There are multiple possibilities for this:")
+		InfoNote("  * It might be dead")
+		InfoNote("  * You might be using the wrong keyword (use `xset kw` to update if needed)")
+		InfoNote("  * It might be flagged nowhere")
+		InfoNote("You have previously seen ", full_mob_name, " in:")
+		search_rooms_results(possible_rooms)
 	end
 
 --	[[ Hunt trick ]]
@@ -3047,20 +3107,20 @@ end
 					end
 				end
 
-				function sort_by_count(a, b)
-					if a.count > b.count then
-						return true
-					elseif	a.count < b.count then
-						return false
-					else
-						return a.rmid < b.rmid
-					end
-				end
-
-				table.sort(results, sort_by_count)
+				table.sort(results, sort_rooms_by_count)
 			end
 
 			search_rooms_results(results)
+		end
+	end
+
+	function sort_rooms_by_count(a, b)
+		if a.count > b.count then
+			return true
+		elseif	a.count < b.count then
+			return false
+		else
+			return a.rmid < b.rmid
 		end
 	end
 


### PR DESCRIPTION
Before, when doing xcp/qw: 
![MUSHclient -  Aardwolf  2021-06-04 17 20 45](https://user-images.githubusercontent.com/84752725/120863800-3496ee80-c559-11eb-90ad-e48cf7aae24a.png)

With this change:
![MUSHclient -  Aardwolf  2021-06-04 17 28 58](https://user-images.githubusercontent.com/84752725/120864528-59d82c80-c55a-11eb-90ef-28c72871f1aa.png)

When you do qw with an argument ("qw hide spider") it won't show this message; only when it's being used to track a quest/cp/gq target.

When hunt trick fails on the first target (meaning not find `hunt guard` and then fail on `hunt 2.guard`, but only when it fails on `hunt guard`), it will fall back to quick where, which then will check the mobs db if not found:
![MUSHclient -  Aardwolf  2021-06-04 19 00 08](https://user-images.githubusercontent.com/84752725/120870502-1801b300-c567-11eb-99c8-54fd9b45b0ba.png)

This will happen when ht is used without args or if you're using `xcp mode ht`. It won't happen if you manually use hunt trick with, for example, `ht large firefly`.