### PR TITLE
Show a changelog in game

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -221,6 +221,7 @@
 	local win_hotspots = {}
 	local win_target_hotspots = {}
 	local win_hide_settings_button = GetVariable("mcvar_window_hide_settings_button") or "off"
+	local last_installed_version = GetVariable("last_installed_version")
 
 -- [[ S&D window color data]]
 	local win_bgcolor = 0x000000
@@ -296,6 +297,116 @@
 -- [[ S&D dev stuff ]]
 	local debug_mode = GetVariable("debug_mode") or "off"
 
+	local CHANGELOG = {
+		[5.0] = 	{
+					features = {
+						"Added long-awaited mob database!",
+						"Added 'snd reload' so you do not have to open Plugins to reinstall.",
+					},
+					changes = {
+						"Changed how the help files look. See 'xhelp' for more info."
+					},
+				},
+		[5.2] =	{
+					fixes = {
+						"Fixed indexing error bugs.",
+						"Added 'ak' back to the public version and fixed the bug that would split commands erroneously.",
+					},
+				},
+		[5.3] =	{
+					fixes = {
+						"Fixed (hopefully) instances where the mob is killed in one hit and not added to mob database.",
+					},
+				},
+		[5.4] =	{
+					fixes = {
+						"The quick kill command was not executing single letter commands. Now fixed.",
+					},
+				},
+		[5.5] =	{
+					features = {
+						"'xhelp summary' will provide a summary of all commands. For more details, visit each help file.",
+					},
+					fixes = {
+						"Migrating Pwar's database would not work because the SnDdb database was not created yet. Fixed.",
+						"Quick kill commands would not accept multiple word commands.",
+					},
+				},
+		[5.6] =	{
+					features = {
+						"Ability to change mob keywords with 'xset kw <mob name>'. When given a mob name it will update the keyword for the currently targeted mob. Without supplying a mob name it will open a series of dialog boxes to rename any mob.",
+						"Reorder the list of rooms to look for a mob based on the number of times you have seen it there already.",
+						"Scan and consider improvements:",
+						">Added a new setting, 'xset autocon', to enable automatically doing a consider when travelling to a room with 'nx' or 'go'. If your current target is not found it will then perform a scan. Any mobs found in the current room are added to the mobs database.",
+						">Tag mobs in scan and consider with [GQ] when part of a gquest, [CP] when part of a campaign, and [Q] when part of a quest",
+						">If autocon is disabled, it will now perform a full scan instead of a quick scan. The new tags should make this more informative.",
+						">Play a sound when your current target is found in the current room (via scan or consider), a different sound when a non-active target is found in the current room, and a third sound if a target is found nearby according to scan. Toggled with 'xset sound' and expects soundpack to be enabled for full functionality.",
+						"Quest targets show up in the target window when you're on a quest, and quest status shows up when you've either killed the target or when you can take a quest.",
+						"'xcp' with no arguments optionally targets the quest mob. Toggle this behaviour with 'xcp quest'",
+						"New command 'xqt' will target the quest mob",
+					},
+					fixes = {
+						"Migrating Pwar's database should be nearly instantaneous."
+					},
+				},
+		[5.61] ={
+					features = {
+						"Will now automatically download the sounds set up by Naricain for snd events.",
+						"Changes to the sorting of room-based CPs and GQs to better highlight when a particular area is likely to have your target and when it is not when more than one area matches. It also makes it more clear when there are multiple, possible targets in different areas."
+					},
+					fixes = {
+						"Some time ago, a change was made to how MUSHclient handled GMCP data. This was never reflected in SnD, so it broke a few things, namely 'xq' and 'noexp'. This has now been fixed."
+					},
+				},
+		[5.62] ={
+					features = {
+						"Will now automatically download the sounds set up by Naricain for snd events.",
+						"Changes to the sorting of room-based CPs and GQs to better highlight when a particular area is likely to have your target and when it is not when more than one area matches. It also makes it more clear when there are multiple, possible targets in different areas."
+					},
+					fixes = {
+						"Some time ago, a change was made to how MUSHclient handled GMCP data. This was never reflected in SnD, so it broke a few things, namely 'xq' and 'noexp'. This has now been fixed."
+					},
+				},
+		[5.63] ={
+					features = {
+						"Added more customization options for the action to take when arriving in a room via nx or go. Use 'help xset nx' for details. The 'xset autocon' option was removed as this is much more flexible.",
+						"Added the ability to customize the target window font. You can do this by right clicking on the top of the window and choosing 'Change font'.",
+						"Search & Destroy will automatically check for new updates every hour and prompt you to get the update. This can be disabled with 'snd check_update'.",
+						"Add a line between quest targets and campaign/gquest targets."
+
+					},
+					fixes = {
+						"Downloading sounds should now work.",
+						"Initialize the hide windows setting so people's windows don't disappear on update.",
+					},
+				},
+		[5.65] ={
+					features = {
+						"Added the ability to customize the target window colors. You can do this by right clicking on the top of the window and selecting a color in the 'Change colors' submenu.",
+
+					},
+					changes = {
+						"Tweak version checking behaviour.",
+					},
+				},
+		[5.66] ={
+					features = {
+						"Added a settings button to the target list. It opens the same menu as right clicking on the top bar, this should just be more discoverable.",
+						"When setting quick kill command, can optionally add 'notarg' to the command to prevent snd from attaching a target to your command. This is useful if you have plugin or script that already captures the mob's name and an alias to act upon it. Probably a niche feature, but it is added for the few that can find it helpful.",
+
+					},
+					changes = {
+						"Beautify and improve tables shown in the mud. No underlines, adding alternating background colors (customizable), show room notes on the rooms table.",
+					},
+				},
+		[5.66] ={
+					fixes = {
+						"A previous change broke the 'xm' command. It should be fixed now.",
+					},
+				},
+	}
+
+
 --	[[ Plugin broadcast/receive process ]]
 	function OnPluginBroadcast(msg, id, name, text)
 		if (id == plugin_id_gmcp_handler) then
@@ -338,6 +449,7 @@
 
 		migrate_database()
 		download_sounds(function() end)
+		show_changelog(false)
 	end
 
 	function migrate_database()
@@ -442,6 +554,89 @@
 			DROP TABLE old_mobs;
 			COMMIT;
 		]])
+	end
+
+	function show_changelog(all_changes)
+		local changes_to_show = {}
+
+		if all_changes then
+			changes_to_show = CHANGELOG
+		elseif last_installed_version then
+			last_installed_version = tonumber(last_installed_version)
+
+			for version, notes in pairs(CHANGELOG) do
+				if version > last_installed_version then
+					changes_to_show[version] = notes
+				end
+			end
+		else
+			-- show only the latest change
+			local latest_change_num = -1
+			for version, notes in pairs(CHANGELOG) do
+				if version > latest_change_num then
+					latest_change_num = version
+				end
+			end
+			changes_to_show[latest_change_num] = CHANGELOG[latest_change_num]
+		end
+		display_changes(changes_to_show)
+
+		last_installed_version = PLUGIN_VERSION
+		SetVariable("last_installed_version", tostring(PLUGIN_VERSION))
+	end
+
+	function display_changes(changes_to_show)
+		local versions = {}
+		for version, notes in pairs(changes_to_show) do
+			table.insert(versions, version)
+		end
+		if #versions == 0 then
+			Note("No versions")
+			return
+		end
+		table.sort(versions, function(a, b) return a > b end)
+
+		local output = {}
+		local function write_notes(lines)
+			for i, line in ipairs(lines) do
+				local indent_length = line:match("^>") and 8 or 4
+				line = line:gsub("^>", "")
+				local indent = string.rep(" ", indent_length)
+				local indent1 = string.rep(" ", indent_length - 4) .. "  * "
+
+				line = helpWrap(line, 76, indent, indent1):gsub("\n", "\r\n" .. indent)
+				table.insert(output, line)
+			end
+		end
+
+		for i, version in ipairs(versions) do
+			local head = string.format("*** Version %s ***", tostring(version))
+			local notes = changes_to_show[version]
+			table.insert(output, head)
+			table.insert(output, "")
+
+			if notes.features then
+				table.insert(output, "FEATURES:")
+				write_notes(notes.features)
+				table.insert(output, "")
+			end
+
+			if notes.changes then
+				table.insert(output, "CHANGES:")
+				write_notes(notes.changes)
+				table.insert(output, "")
+			end
+
+			if notes.fixes then
+				table.insert(output, "FIXES:")
+				write_notes(notes.fixes)
+				table.insert(output, "")
+			end
+			table.insert(output, "\r\n")
+		end
+
+		utils.editbox("", "Changelog", table.concat(output, "\r\n"), win_font, win_font_size,
+			{ read_only = true, cancel_button = "Close" , prompt_height = 12, box_width = 1000})
 	end
 
 	local init_called = 0
@@ -4411,6 +4606,7 @@ end
 			"-",
 			hide_settings,
 			"Check for Updates",
+			"Changelog",
 			"Help",
 		}
 		result = WindowMenu (win,
@@ -4477,6 +4673,8 @@ end
 			xg_draw_window()
 		elseif result == "Help" then
 			Execute("xhelp")
+		elseif result == "Changelog" then
+			show_changelog(true)
 		elseif result == nil or result == "" then
 			return
 		else

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -228,7 +228,7 @@
 
 	NOTE_COLORS = {
 		INFO 					= "#FF5000",
-		INFO_HIGHLIGHT 			= "#00C040",
+		INFO_HIGHLIGHT 			= "#00B4E0",
 
 		IMPORTANT 				= "#FFFFFF",
 		IMPORTANT_HIGHLIGHT 	= "#00FF00",
@@ -563,6 +563,7 @@
 			changes_to_show = CHANGELOG
 		elseif last_installed_version then
 			last_installed_version = tonumber(last_installed_version)
+			DebugNote("Last installed version ", last_installed_version)
 
 			for version, notes in pairs(CHANGELOG) do
 				if version > last_installed_version then
@@ -586,17 +587,17 @@
 	end
 
 	function display_changes(changes_to_show)
+		local line_width = 80
 		local versions = {}
 		for version, notes in pairs(changes_to_show) do
 			table.insert(versions, version)
 		end
 		if #versions == 0 then
-			Note("No versions")
+			DebugNote("No updates to show in changelog")
 			return
 		end
 		table.sort(versions, function(a, b) return a > b end)
 
-		local output = {}
 		local function write_notes(lines)
 			for i, line in ipairs(lines) do
 				local indent_length = line:match("^>") and 8 or 4
@@ -604,39 +605,42 @@
 				local indent = string.rep(" ", indent_length)
 				local indent1 = string.rep(" ", indent_length - 4) .. "  * "
 
-				line = helpWrap(line, 76, indent, indent1):gsub("\n", "\r\n" .. indent)
-				table.insert(output, line)
+				line = helpWrap(line, 76, indent, indent1):gsub("\n", "\n" .. indent)
+				ColourNote(NOTE_COLORS.INFO, "", line)
 			end
 		end
 
+		InfoNote(string.rep("=", 25), " Search and Destroy Changelog ", string.rep("=", 25), "\n")
 		for i, version in ipairs(versions) do
-			local head = string.format("*** Version %s ***", tostring(version))
+			local head = string.format(" Version %s ", tostring(version))
+			ColourTell(NOTE_COLORS.INFO, "", "===")
+			ColourTell(NOTE_COLORS.INFO_HIGHLIGHT, "", head)
+			ColourNote(NOTE_COLORS.INFO, "", string.rep("=", line_width - #head - 3))
 			local notes = changes_to_show[version]
-			table.insert(output, head)
-			table.insert(output, "")
 
 			if notes.features then
-				table.insert(output, "FEATURES:")
+				ColourNote(NOTE_COLORS.INFO_HIGHLIGHT, "", "FEATURES:")
 				write_notes(notes.features)
-				table.insert(output, "")
+				print("")
 			end
 
 			if notes.changes then
-				table.insert(output, "CHANGES:")
+				ColourNote(NOTE_COLORS.INFO_HIGHLIGHT, "", "CHANGES:")
 				write_notes(notes.changes)
-				table.insert(output, "")
+				print("")
 			end
 
 			if notes.fixes then
-				table.insert(output, "FIXES:")
+				ColourNote(NOTE_COLORS.INFO_HIGHLIGHT, "", "FIXES:")
 				write_notes(notes.fixes)
-				table.insert(output, "")
+				print("")
 			end
-			table.insert(output, "\r\n")
+			print("")
 		end
 
-		utils.editbox("", "Changelog", table.concat(output, "\r\n"), win_font, win_font_size,
-			{ read_only = true, cancel_button = "Close" , prompt_height = 12, box_width = 1000})
+		if changes_to_show ~= CHANGELOG then
+			InfoNote("To see changes from all versions select ", "Changelog", " from the settings menu in the S&D window.\n")
+		end
 	end
 
 	local init_called = 0


### PR DESCRIPTION
When you install the plugin it will check your last version and display all the changes between your last known version and the updated one:
![MUSHclient -  Aardwolf  2021-06-04 22 27 30](https://user-images.githubusercontent.com/84752725/120877623-8ce3e580-c585-11eb-87b3-fcd9dc0db687.png)

It also means we'll start remembering the last client version in a variable. If it's nil we'll just show the latest change notes.

There's also a Changelog option in the menu to show all changes ever.

I changed the green highlight color to this light blue one. I think it contrasts as well as the green but looks a bit better with the orange. Comparison of some of the combinations I tried that ended up contrasting well:
![HgeON4Y - Imgur](https://user-images.githubusercontent.com/84752725/120877689-f19f4000-c585-11eb-9216-4475e81e91a6.png)

I also tried making a window pop up with the changelog but it did not look great
![changelog](https://user-images.githubusercontent.com/84752725/120877705-07146a00-c586-11eb-8225-5cc41dc4c5b9.png)
