### PR TITLE
Shorter tables to at most 80 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **v5.72**<br>
 *fix* : Fixed a bug where disabling/enabling the settings button and then click on one of the other buttons would cause a copy to appear offset.<br>
+*change* : Shorten table widths so they're at most 80 characters.<br>
 
 **v5.71**<br>
 *feature* : 'xset win' now accepts 'min(imize)', 'collapse', 'max(imize)', and 'expand' as optional arguments to shrink or expand the window.<br>

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -2489,44 +2489,47 @@ end
 		end
 		if silentMode == "off" then
 			if (#list > 0) then
-				ColourNote("#808080", "", string.rep("-", 90))
+				ColourNote("#808080", "", string.rep("-", 80))
 				--[[if list[1].link_type == "room" then
 					for _,v in ipairs(list) do
 						if string.match(v.roomName, "^Hiding from") then
 							v.arid = "zz" .. v.arid ]]--
 
 				for i,v in ipairs (list) do
-					local mob_text = string.format("%s%s",  ((v.is_dead == "no") and "" or "[Dead] "), v.mob):sub(1, 32)
+					local mob_text = string.format("%s%s",  ((v.is_dead == "no") and "" or "[D] "), v.mob)
 					local arid = v.arid:sub(1, 10)
 					local background = (i % 2) == 0 and text_colors.alternating_row or ""
 					local link_text
 					local tooltip = "Target cp mob " .. i .. " - " .. mob_text .. " (" .. v.arid .. ")"
 					local notehelp = "Show notes for item " .. i
 					local color = color_for_target(v)
+					mob_text = ellipsify(mob_text, 32)
 					if (v.link_type == "area") then
-						link_text = string.format(" %2d  %-32s - %-10s", i, mob_text, arid)
+						link_text = string.format("%2d  %-32s - %-10s", i, mob_text, arid)
 						Hyperlink("xcp " .. i, link_text, tooltip, color, background, 0, 1)
-						Hyperlink("roomnote area " .. v.arid, string.format("  %-38s", "[notes]"), notehelp, ((v.is_dead == "yes") and "#006000" or "lightgreen"), background, 0, 1)
+						Hyperlink("roomnote area " .. v.arid, string.format("  %-29s", "[notes]"), notehelp, ((v.is_dead == "yes") and "#006000" or "lightgreen"), background, 0, 1)
 					elseif v.link_type == "room" and v.unlikely then
 						ColourNameToRGB(text_colors.unlikely_tag)
-						Hyperlink("xcp " .. i, string.format(" %2d ", i), tooltip, color, background, 0, 1)
-						Hyperlink("xcp " .. i, "(unlikely)", tooltip, text_colors.unlikely_tag, background, 0, 1)
-						mob_text = mob_text:sub(1,22)
-						link_text = string.format(" %-22s - %-10s  %-38s", mob_text, v.arid, roomText)
+						Hyperlink("xcp " .. i, string.format("%2d  ", i), tooltip, color, background, 0, 1)
+						Hyperlink("xcp " .. i, "(U) ", tooltip, text_colors.unlikely_tag, background, 0, 1)
+						mob_text = ellipsify(mob_text, 28)
+						local roomText = string.format("'%s'", ellipsify(v.roomName, 27))
+						link_text = string.format("%-28s - %-10s  %-29s", mob_text, v.arid, roomText)
 						Hyperlink("xcp " .. i, link_text, tooltip, color, background, 0, 1)
 					elseif v.link_type == "room" then
-						local roomText = string.format("%5s", v.roomid) .. ": '" .. v.roomName
-						roomText = roomText:sub(1, 39) .. "'"
-						link_text = string.format(" %2d  %-32s - %-10s  %-38s", i, mob_text, v.arid, roomText)
+						local roomText = string.format("'%s'", ellipsify(v.roomName, 27))
+						link_text = string.format("%2d  %-32s - %-10s  %-29s", i, mob_text, v.arid, roomText)
 						Hyperlink("xcp " .. i, link_text, tooltip, color, background, 0, 1)
 					elseif (v.link_type == "unknown") then
-						link_text = string.format(" %2d  %-32s - unknown: '%s'%s", i, mob_text, v.location, string.rep(" ", 39 - #v.location))
+						local location = ellipsify(v.location, 30)
+						link_text = string.format("%2d  %-32s - unknown: '%s'%s", i, mob_text, location, string.rep(" ", 30 - #location))
 						tooltip = "Location not found in mapper database"
 						Hyperlink(" ", link_text, tooltip, color, background, 0, 1)
+
 					end
 					print("")
 				end
-					ColourNote("#808080", "", string.rep("-", 90))
+					ColourNote("#808080", "", string.rep("-", 80))
 					ColourNote("#808080", "", "Type 'xcp <index>' or click link to go to that target.")
 			else
 				InfoNote("   No target items to show.")
@@ -2534,11 +2537,19 @@ end
 		end
 	end
 
+	function ellipsify(str, max_length)
+		if #str <= max_length then
+			return str
+		else
+			return str:sub(1, max_length - 1) .. "…"
+		end
+	end
+
 	function print_room_links_ignored()
 		local ig = room_targets_ignored
-		ColourNote("#808080", "", string.rep("-", 90))
+		ColourNote("#808080", "", string.rep("-", 80))
 		for i,v in ipairs (ig) do
-			local link = string.format(" ** Ignoring due to level: %s - %5s '%s' (%s) [%s-%s]", v.mob, v.roomid, v.roomName, v.arid, v.minlvl, v.maxlvl)
+			local link = string.format(" ** Ignoring due to level: %s - '%s' (%s) [%s-%s]", v.mob, v.roomName, v.arid, v.minlvl, v.maxlvl)
 			Hyperlink("xmapper move " .. v.roomid, link, "Move to room " .. v.roomid, "#002460", "", 0, 1)
 			print("")
 		end
@@ -3363,27 +3374,28 @@ end
 		local line_num = 0
 		local last_area = ""
 		local has_chance = #results > 0 and results[1].percentage
-		local dashes = 74
-		ColourTell("#808080", "", string.format("\nIndex   Location %38s", "(uid)"))
+		local width = 69
+		ColourTell("#808080", "", string.format("\nXCP  Location %36s", "(uid)"))
 		if has_chance then
-			dashes = 85
+			width = 80
 			ColourTell("#808080", "", string.format("%20s", "(chance)"))
 		end
 		print("")
-		ColourNote("#808080", "", string.rep("-", dashes))
+		ColourNote("#808080", "", string.rep("-", width))
 		for i,v in ipairs (results) do
 			line_num = line_num + 1
 			local background = (line_num % 2) == 0 and text_colors.alternating_row or ""
 			local instruction = "go " .. mapper_area_index
 			if (last_area ~= v.arid) then
+				local padding = string.rep(" ", width - 5 - #v.arid)
 				if (mapper_area_index == 0) then
-					local areaLine = string.format("%3d     %-76s", mapper_area_index, v.arid)
+					local areaLine = string.format("%2d   %s%s", mapper_area_index, v.arid, padding)
 					Hyperlink("go " .. mapper_area_index, areaLine, "go to area " .. v.arid, "silver", background, 0, 1)
 					gotoList[mapper_area_index] = v.arid
 					gotoArea = v.arid
 					mapper_area_index = mapper_area_index + 1
 				else
-					local areaLine = string.format("        %-76s", v.arid)
+					local areaLine = string.format("     %s%s", v.arid, padding)
 					Hyperlink("xrt " .. v.arid, areaLine, "go to area " .. v.arid, "silver", background, 0, 1)
 				end
 				print("")
@@ -3391,8 +3403,8 @@ end
 				last_area = v.arid
 			end
 			background = (line_num % 2) == 0 and text_colors.alternating_row or ""
-			local name = string.gsub(v.name, "@[a-zA-Z]", ""):sub(1, 40)
-			local text = string.format("%3d     %-40s  %-7s ", mapper_area_index, name, string.format("(%s)", v.rmid))
+			local name = ellipsify(string.gsub(v.name, "@[a-zA-Z]", ""), 38)
+			local text = string.format("%2d   %-38s  %-7s ", mapper_area_index, name, string.format("(%s)", v.rmid))
 			Hyperlink("go " .. mapper_area_index, text, "go to item " .. mapper_area_index, "lightblue", background, 0, 1)
 
 			local instruction = "mapper where " .. v.rmid
@@ -3419,7 +3431,7 @@ end
 		if (mapper_area_index == 0) then
 			InfoNote("No matching rooms found.")
 		end
-		ColourNote("#808080", "", string.rep("-", dashes))
+		ColourNote("#808080", "", string.rep("-", width))
 		ColourNote("#808080", "", "Type 'go <index>' or click link to go to that room.\n")
 	end
 
@@ -3812,6 +3824,7 @@ end
 			Simulate("You still have to kill * a former court jester (The Labyrinth)\n")
 			Simulate("You still have to kill * Parent (A Cold Path - Dead)\n")   --dead and unknown
 			Simulate("You still have to kill * a wealth redistribution specialist (Empyrean, Streets of Downfall)\n") -- long unnknown
+			Simulate("You still have to kill * a wealth redistribution specialist (Empyrean, Streets of Downfall and Upfall and Other Things)\n") -- really long unnknown
 			Simulate("You still have to kill * Laurence, archangel of the sword and shield and other implements of war (The Flying Citadel)\n") -- long known
 			Simulate("You still have to kill * the spirit of Bakarne (The Empire of Aiighialla)\n")
 			Simulate("You still have to kill * a sinister vandal (The Three Pillars of Diatz)\n") -- noscan
@@ -3833,6 +3846,8 @@ end
 			Simulate("You still have to kill * a hideously hairy spider (The Landing)\n") -- nowhere
 			Simulate("You still have to kill * Sssssuper long mob name that should break formatting (This can't be a real room, right)\n") -- long unknown
 			Simulate("You still have to kill * Laurence, archangel of the sword and shield and other implements of war (In the clouds)\n") -- long known
+			Simulate("You still have to kill * a giant bee (An Impossibly Dark Intersection in the Labyrinth)\n") -- long room name
+
 		end
 		Simulate("Note: Dead means that the target is dead, not that you have killed it.\n")
 		Simulate("\n")


### PR DESCRIPTION
This was requested as not everyone plays on large screens.

It wasn't so bad:
* Area-based CPs didn't need much change other than to just remove some whitespace. Also if the area name is really long it has to be truncated, but in practice no current area name is long enough that it will need that, but who knows in the future
*  In room-based CPs I removed the room id from the table. It wasn't always accurate anyhow because there could be many rooms with that id. I added truncation to the room names and shortened (unlikely) down to (U)
* I changed [Dead] to [D] in both area and room-based CPs
* I shortened the space taken by numbers in the room list from 5 to 3
* I shortened the area for room names in the room list from 40 to 38. Very few rooms are that long anyhow
* Removed a bit of padding here and there but in general there's still 2 characters between different parts of the tables
* Added a truncation method `ellipsify` that will cut off a name and add an ellipsis at the end if it's too long. Right now it uses the unicode ellipsis `…` that only takes a single character so hopefully that works on everyone's clients. The mud can't accept the character but we're not limited by that. If it's a problem it can be changed to three periods.

Screenshots:
![MUSHclient -  Aardwolf  2021-06-05 19 54 21](https://user-images.githubusercontent.com/84752725/120908404-d7be3580-c637-11eb-9a37-ae8e0b8ddbc8.png)

![MUSHclient -  Aardwolf  2021-06-05 19 54 39](https://user-images.githubusercontent.com/84752725/120908408-e278ca80-c637-11eb-8a43-29d1a0b86d1f.png)

![MUSHclient -  Aardwolf  2021-06-05 19 56 06](https://user-images.githubusercontent.com/84752725/120908425-194ee080-c638-11eb-85cd-81ff60211ce9.png)


![MUSHclient -  Aardwolf  2021-06-05 19 55 47](https://user-images.githubusercontent.com/84752725/120908422-0c31f180-c638-11eb-8d07-33362f1d1c3d.png)

