### PR TITLE
Reset next room after changing targets

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -2545,6 +2545,7 @@ end
 			local action = xcp_action_mode
 			gotoArea = -1
 			gotoIndex = 1
+			next_room = -1
 			gotoList = {}
 			if (t ~= nil) and (ri.rmid ~= nil) then
 				full_mob_name = t.mob
@@ -3296,6 +3297,7 @@ end
 	function search_rooms_results(results)	-- Display list of 'go' links from hunt-trick, quick-where, etc.
 		gotoArea = -1
 		gotoIndex = 1
+		next_room = -1
 		gotoList = {}
 		local mapper_area_index = 0
 		local line_num = 0


### PR DESCRIPTION
This was a bit of a subtle one:
You're in a campaign and have a target. You use nx or go to get there, kill it, then use xcp to pick the next target. You're either in the same area as it already, or it's a room-based cp so xcp doesn't make you run to another area. You see there's 2 rooms. You do nx. It picks the second room instead of the first.

This was happening because next_room wasn't being reset after doing xcp so it was going "Oh, you're currently in the first room, let's go to the second" but that was straight up wrong.

Reset it to -1 and bingo bango bongo you're good to go