### PR TITLE
Don't count rooms out of range when showing campaign rooms

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -2324,13 +2324,13 @@ end
 			local last_mob_sig = ""
 			for row in db:nrows(select) do			-- if not row then / print("error - room db search returned no rows") / elseif not row.areaName then / print("area name missing from row") / end
 				if (area_range_index[row.areaName]) then	-- don't include areas that never contain quest mobs
-					results_found = true
 					local mob_sig = row.arid .. "|" .. v.mob
 					if (mob_sig ~= last_mob_sig) then
 						last_mob_sig = mob_sig
 						local area_min_lvl = (area_range_index[row.areaName].min) or 1
 						local area_max_lvl = (area_range_index[row.areaName].max) or 300
 						if (level_taken >= area_min_lvl) and (level_taken <= (area_max_lvl+25)) then	-- limit results to sensible level range.
+							results_found = true
 							table.insert(areas_sql, fixsql(row.arid))
 							table.insert(possibilities, {
 								mob = v.mob,


### PR DESCRIPTION
If you had a room-based cp/gq and one of the rooms was unmapped, but there was an identically named room that was mapped in another area that was out of range for the cp/gq, you would get no entry in your targets table. This small change makes it so that in this case you will still get an "unknown" entry. It won't help when you have multiple rooms in the same range, some of them unmapped, but at least you'll still have an entry in the table in this case, even though it may be the wrong one.

Before (simulate cp at level 15)
![MUSHclient -  Aardwolf  2021-06-12 19 44 25](https://user-images.githubusercontent.com/84752725/121791306-9f2dd700-cbb6-11eb-838e-54893f541dcb.png)

Same cp at level 14 after the change:
![MUSHclient -  Aardwolf  2021-06-12 19 45 00](https://user-images.githubusercontent.com/84752725/121791320-b53b9780-cbb6-11eb-8d66-9113032365b9.png)

