### PR TITLE
Do a qw exact after a hunt trick on an activity target

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -3269,7 +3269,12 @@ end
 	function ht_complete(name, line, wildcards)
 		EnableTriggerGroup("AutoHunt", false)
 		local ix = ht.index or 1
-		qw_arg(ix, current_target.keyword)
+		if has_activity_target() then
+			qw.index = ix
+			qw_exact()
+		else
+			qw_arg(ix, current_target.keyword)
+		end
 		ht_reset()
 	end
 

--- a/changelog
+++ b/changelog
@@ -1,4 +1,9 @@
 {
+    "5.83": {
+        "fixes": [
+            "Fixed an issue where ht followed by qw was not correctly matching mobs that had a name that didn't match its keywords (looking at you, school of horror)"
+        ]
+    },
     "5.82": {
         "fixes": [
             "xset kk correctly targets with multiple commands separated by semicolons, and takes notarg argument into account for each command individually"


### PR DESCRIPTION
When doing a hunt trick against a mob in the target list, it was then following up with a quick where that was looking for partial matches. When dealing with mobs that have a keyword that doesn't show up in their name (like imm mobs in sohtwo) this resulted in qw failing to find them. Instead, it should be doing an exact match when the target of ht was an activity mob.