### PR TITLE
cross off cp mobs on death when cp is active in list, even when on gq

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1703,7 +1703,7 @@ end
 		return guess
 	end
 
-	function target_matches_current_target(target)
+	function target_matches_current_target(target, index)
 		if not current_target then
 			return false
 		elseif target.mob ~= current_target.name then
@@ -1715,6 +1715,8 @@ end
 		elseif target.arid ~= current_target.area then
 			return false
 		elseif current_activity ~= current_target.activity then
+			return false
+		elseif index and index ~= current_target.index then
 			return false
 		else
 			return true
@@ -2015,7 +2017,7 @@ end
 	end
 
 	function cp_mob_killed()
-		if (player_on_gq == "no") then
+		if current_activity == "cp" then
 			xcp_retry_stat = 1
 			qw_reset(false)
 			last_kill_index = get_last_kill_index()
@@ -2281,6 +2283,9 @@ end
 
 --	[[ Gquest general status functions ]]
 	function gq_mob_killed()
+		if current_activity ~= "gq" then
+			return
+		end
 		last_kill_index = get_last_kill_index()
 		if last_kill_index and main_target_list[last_kill_index] then
 			local x = tonumber(main_target_list[last_kill_index].qty) - 1
@@ -4355,6 +4360,7 @@ end
 
 	function gq_area_targets()
 		return {
+			{ count = 2, name = "a horse", location =  "Kul Tiras" },
 			{ count = 1, name = "a horse", location =  "Kul Tiras" },
 			{ count = 1, name = "a treble clef", location =  "Art of Melody" },
 			{ count = 1, name = "a spider", location =  "Gallows Hill" },
@@ -5152,7 +5158,7 @@ end
 				counts = string.format("(%i/%i) ", v.index, v.duplicates)
 			end
 			local link = string.format("%2s) %s%s%s - %s", index, counts, qty, mob, location)
-			local color = ColourNameToRGB(color_for_target(v, is_cp_or_gq_mob_targeted() and current_target.index == index))
+			local color = ColourNameToRGB(color_for_target(v, target_matches_current_target(v, index)))
 			local hs_left = 6
 			local hs_top = (targ_list_top + ((index-1) * font_height))
 			local hs_right = math.min(hs_left + WindowTextWidth(win, font, link), win_width - 5)

--- a/changelog
+++ b/changelog
@@ -5,7 +5,9 @@
         ],
         "fix": [
             "When using `ht <mob>` explicitly and it finds a campaign target, keep the keyword the same as what was entered so quick kill uses it.",
-            "Name line in graffiti won't be hidden (it was accidentally matching scan)"
+            "Name line in graffiti won't be hidden (it was accidentally matching scan)",
+            "cp targets should be properly crossed off the target list even if you are on a gq",
+            "target highlighting should be more accurate, particularly when switching between gq and cp targets"
         ]
     },
     "5.85": {


### PR DESCRIPTION
If cp is currently the active list in the target window but you're on a gq, then killing a cp mob won't cross anything off. This fixes it so it will cross mobs off of the current target list, whichever it is. 

It should also be a little better about highlighting the correct target, even when you switch between cp and gq.

Known issue:
If you have duplicate mobs on the list (same mob name/area, different mobkey) then it will behave a bit weird when you select the second one and may jump back to the first. I'm not too concerned about this because it's rare and technically they're the same mob from S&D's perspective.