### PR TITLE
Snd improve damage triggers

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -7512,24 +7512,27 @@ end
 <triggers>
 +<!-- Receive xp -->
 	<trigger match="^You (?:don't )?receive \d+(?:\+\d+)* experience points?\."
-		script="trigger_receive_xp" ignore_case="n" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+		script="trigger_receive_xp" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 <!-- Damage triggers -->
-	<trigger match="^\*?(?:\[\d+\] )?Your \w+ does UN(?:SPEAKABLE|THINKABLE|IMAGINABLE|BELIEVABLE) things to (?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+<trigger match="^\*?(?:\[\d+\] )?Your [A-Za-z ]+ does UN(?:SPEAKABLE|THINKABLE|IMAGINABLE|BELIEVABLE) things to (?<mob_name>\S.*)! \[\d+\]$"
+		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
-	<trigger match="^^\*?(?:\[\d+\] )?You damage (?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+	<trigger match="^\*?(?:\[\d+\] )?You damage (?<mob_name>\S.*)[!\.] \[\d+\]$"
+		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
-	<trigger match="^\*?(?:\[\d+\] )?Your \w+ (?:damages|misses|tickles|bruises|scratches|grazes|nicks|scars|hits|injures|wounds|mauls|maims|mangles|mars|lacerates|decimates|devastates|eradicates|obliterates|extirpates|incinerates|mutilates|disembowels|massacres|dismembers|rends|blasts|demolishes|shreds|destroys|pulverizes|vaporizes|atomizes|asphyxiates|ravages|fissures|liquidates|evaporates|sunders|tears into|wastes|cremates|annihilates|implodes|exterminates|shatters|slaughters|ruptures|nukes|glaciates|meteorites|supernovas) (?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y" ignore_case="y" > </trigger>
+	<trigger match="^\*?(?:\[\d+\] )?Your [A-Za-z ]+ (?:damages|misses|tickles|bruises|scratches|grazes|nicks|scars|hits|injures|wounds|mauls|maims|mangles|mars|lacerates|decimates|devastates|eradicates|obliterates|extirpates|incinerates|mutilates|disembowels|massacres|dismembers|rends|blasts|demolishes|shreds|destroys|pulverizes|vaporizes|atomizes|asphyxiates|ravages|fissures|liquidates|evaporates|sunders|tears into|wastes|cremates|annihilates|implodes|exterminates|shatters|slaughters|ruptures|nukes|glaciates|meteorites|supernovas) (?<mob_name>\S.*)[!\.] \[\d+\]$"
+		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y" ignore_case="y" > </trigger>
 
-	<trigger match="^\*?(?:\[\d+\] )?Your \w+ (?:- BLASTS -|-= DEMOLISHES =-|\*\* SHREDS \*\*|\*\*\*\* DESTROYS \*\*\*\*|\*\*\*\*\* PULVERIZES \*\*\*\*\*|-=- VAPORIZES -=-|<-==-> ATOMIZES <-==->|<-:-> ASPHYXIATES <-:->|<-\*-> RAVAGES <-\*->|<>\*<> FISSURES <>\*<>|<\*><\*> LIQUIDATES <\*><\*>|<\*><\*><\*> EVAPORATES <\*><\*><\*>|<-=-> SUNDERS <-=->|<=-=><=-=> TEARS INTO <=-=><=-=>|<->\*<=> WASTES <=>\*<->|<-\+-><-\*-> CREMATES <-\*-><-\+->|<\*><\*><\*><\*> ANNIHILATES <\*><\*><\*><\*>|<--\*--><--\*--> IMPLODES <--\*--><--\*-->|<-><-=-><-> EXTERMINATES <-><-=-><->|<-==-><-==-> SHATTERS <-==-><-==->|<\*><-:-><\*> SLAUGHTERS <\*><-:-><\*>|<-\*-><-><-\*-> RUPTURES <-\*-><-><-\*->|<-\*-><\*><-\*-> NUKES <-\*-><\*><-\*->|-<\[=-\+-=\]<:::<>:::> GLACIATES <:::<>:::>\[=-\+-=\]>-|	<-=-><-:-\*-:-><\*--\*> METEORITES <\*--\*><-:-\*-:-><-=->|<-:-><-:-\*-:-><-\*-> SUPERNOVAS <-\*-><-:-\*-:-><-:->) (?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+	<trigger match="^\*?(?:\[\d+\] )?Your [A-Za-z ]+ (?:- BLASTS -|-= DEMOLISHES =-|\*\* SHREDS \*\*|\*\*\*\* DESTROYS \*\*\*\*|\*\*\*\*\* PULVERIZES \*\*\*\*\*|-=- VAPORIZES -=-|<-==-> ATOMIZES <-==->|<-:-> ASPHYXIATES <-:->|<-\*-> RAVAGES <-\*->|<>\*<> FISSURES <>\*<>|<\*><\*> LIQUIDATES <\*><\*>|<\*><\*><\*> EVAPORATES <\*><\*><\*>|<-=-> SUNDERS <-=->|<=-=><=-=> TEARS INTO <=-=><=-=>|<->\*<=> WASTES <=>\*<->|<-\+-><-\*-> CREMATES <-\*-><-\+->|<\*><\*><\*><\*> ANNIHILATES <\*><\*><\*><\*>|<--\*--><--\*--> IMPLODES <--\*--><--\*-->|<-><-=-><-> EXTERMINATES <-><-=-><->|<-==-><-==-> SHATTERS <-==-><-==->|<\*><-:-><\*> SLAUGHTERS <\*><-:-><\*>|<-\*-><-><-\*-> RUPTURES <-\*-><-><-\*->|<-\*-><\*><-\*-> NUKES <-\*-><\*><-\*->|-<\[=-\+-=\]<:::<>:::> GLACIATES <:::<>:::>\[=-\+-=\]>-|	<-=-><-:-\*-:-><\*--\*> METEORITES <\*--\*><-:-\*-:-><-=->|<-:-><-:-\*-:-><-\*-> SUPERNOVAS <-\*-><-:-\*-:-><-:->) (?<mob_name>\S.*)! \[\d+\]$"
+		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 	<trigger match="^(?:You assassinate |You catch |You attempt to bury .* deep into |You lunge at)(?<mob_name>.*)(?: with cold efficiency\.| completely off-guard and inflict massive damage on .*\.|'s? back!|with a .*!)$"
-		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
-
+		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+	
+	<trigger match="^(?<mob_name>\S.*) is unaffected by your [A-Za-z ]+!$"
+		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+	
 <!-- Gquest operations -->
 	<!-- group: trg_gq -->
 	<trigger match="^Quest Name\.\.\.\.\.\.\.\.\.: \[ Global quest # (?<gq_id>\d{1,5}) \]$"

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE muclient>
 <!-- Saved on Saturday, July 05, 2008, 4:46 PM -->
 <muclient>
-<plugin version="5.89" name="Search_and_Destroy" id="30000000537461726C696E67" date_written="2018-12-31 23:00:00" author="Crowley and Naricain" language="Lua" purpose="Safe, legal Search and Destroy" save_state="y" requires="4.90" >
+<plugin version="5.89" name="Search_and_Destroy" id="30000000537461726C696E67" date_written="2018-12-31 23:00:00" author="Crowley and Naricain" language="Lua" purpose="Find mobs faster." save_state="y" requires="4.90" >
 <description trim="n"> </description> </plugin>
 
 <!-- Isolinear intermatrix (utility module) -->
@@ -2853,7 +2853,7 @@ end
 		if #str <= max_length then
 			return str
 		else
-			return str:sub(1, max_length - 1) .. "…"
+			return str:sub(1, max_length - 1) .. "â¦"
 		end
 	end
 
@@ -5001,7 +5001,18 @@ end
 				"" .. (tooltip or text), miniwin.cursor_arrow, 0)											-- Tooltip text, cursor shape (hand)
 		end
 	end
-
+	
+	function draw_button_1_B(L, T, text, hsName, tooltip, tdx, tdy)
+		local x,y,w,z = L, T, L+30, T+25											-- x and y values for button boundaries
+		local tx,ty = (x+tdx), (y+tdy)	-- x and y values for text location
+		local bgcolor = 0x000060	-- red
+		local color_1 = 0x80E0E0	-- yellow
+		local color_2 = 0x80E0E0	-- yellow
+		WindowRectOp (win,2, x,y,w,z, bgcolor)												-- Draw background and set color (black)
+		WindowRectOp (win,4, x,y,w,z, color_1, color_2)										-- Draw button border (left/top = light grey, right/bottom = darker grey)
+		WindowText(win, "bt1", text, tx,ty,w-1,z-1, color_1, false)								-- Draw button text ("button" font, light grey)
+	end
+	
 	local win_circle_readout_vars = {
 			["cp"] 	 = { cc, cc1="r", cc2y="", tc1="", tc2="", tdx="", tdy="", text="" },
 			["gq"] 	 = { cc1n="", cc2n="", cc1y="", cc2y="", tc1="", tc2="", tdx="", tdy="", text="" },
@@ -5315,13 +5326,13 @@ end
 		local hs_left, hs_top, hs_right, hs_bottom
 
 		if quest_target.qstat == "0" then
-			text = " You may now quest again"
+			text = " You may now quest again."
 			color = text_colors.quest_available
 		elseif has_active_quest() then
 			color = is_quest_mob_targeted() and text_colors.targeted or text_colors.normal
 			text = string.format(" Q) %s - '%s' (%s)", quest_target.mob, quest_target.room, quest_target.arid)
 		elseif quest_target.qstat == "3" then
-			text = " Quest complete! You may turn it in"
+			text = " Quest complete! You may turn it in."
 			color = text_colors.quest_complete
 		else
 			return false
@@ -5369,7 +5380,7 @@ end
 		local click = ((bit.band(flags, 0x20) == 0) and "L" or "R")
 		local left = WindowHotspotInfo(win, hotspot_id, 1)
 		local top = WindowHotspotInfo(win, hotspot_id, 2)
-		draw_button_1_A(left, top, b.text, hotspot_id.."2", "", b.tdx, b.tdy, true)
+		draw_button_1_B(left, top, b.text, hotspot_id.."2", "", b.tdx, b.tdy, true)
 		Redraw()
 	end
 
@@ -6095,7 +6106,7 @@ end
 			if upstream_version ~= tostring(PLUGIN_VERSION) then
 				callback(upstream_version)
 			elseif log_no_updates then
-				InfoNote("Search&Destroy: No new updates available")
+				InfoNote("Search & Destroy: No new updates are currently available.")
 			end
 		end
 	end
@@ -6151,7 +6162,7 @@ end
 		set_variable("mcvar_automatic_update_checks", automatic_update_checks)
 
 
-		InfoNote("\nSearch&Destroy automatic update checking is now ", string.upper(automatic_update_checks))
+		InfoNote("\nSearch & Destroy automatic update checking is now ", string.upper(automatic_update_checks), ".")
 	end
 
 	function download_sounds(callback)
@@ -6215,7 +6226,7 @@ end
 					if debug_mode == "on" then
 						SetClipboard(page)
 					end
-					DebugNote("Page data was too large for display and has been save to the clipboard")
+					DebugNote("Page data was too large for display and has been saved to the clipboard.")
 				else
 					DebugNote("Page: ", page)
 				end
@@ -7344,7 +7355,7 @@ end
 		xset_sound_onoff = new_val
 		set_variable("mcvar_xset_sound_onoff", xset_sound_onoff)
 
-		InfoNote("\nSearch&Destroy Sounds are now ", string.upper(xset_sound_onoff))
+		InfoNote("\nSearch & Destroy Sounds are now ", string.upper(xset_sound_onoff), ".")
 	end
 
 	function xset_sound()
@@ -7400,6 +7411,7 @@ end
 
 	function trigger_damage_done(name, line, wildcards)
 		last_mob_damaged = Trim(wildcards.mob_name)
+		print(last_mob_damaged)
 	end
 
 	function set_variable(key, value)
@@ -7501,242 +7513,23 @@ end
 <triggers>
 +<!-- Receive xp -->
 	<trigger match="^You (?:don't )?receive \d+(?:\+\d+)* experience points?\."
-		script="trigger_receive_xp" ignore_case="y" enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
+		script="trigger_receive_xp" ignore_case="n" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 <!-- Damage triggers -->
-	<trigger match="^.+\w tickles +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
+	<trigger match="^\*?(?:\[\d+\] )?Your \w+ does UN(?:SPEAKABLE|THINKABLE|IMAGINABLE|BELIEVABLE) things to (?<mob_name>\S.*)[!\.] \[\d+\]$"
+		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
-	<trigger match="^.+\w bruises +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
+	<trigger match="^^\*?(?:\[\d+\] )?You damage (?<mob_name>\S.*)[!\.] \[\d+\]$"
+		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
-	<trigger match="^.+\w scratches +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
+	<trigger match="^\*?(?:\[\d+\] )?Your \w+ (?:damages|misses|tickles|bruises|scratches|grazes|nicks|scars|hits|injures|wounds|mauls|maims|mangles|mars|lacerates|decimates|devastates|eradicates|obliterates|extirpates|incinerates|mutilates|disembowels|massacres|dismembers|rends|blasts|demolishes|shreds|destroys|pulverizes|vaporizes|atomizes|asphyxiates|ravages|fissures|liquidates|evaporates|sunders|tears into|wastes|cremates|annihilates|implodes|exterminates|shatters|slaughters|ruptures|nukes|glaciates|meteorites|supernovas) (?<mob_name>\S.*)[!\.] \[\d+\]$"
+		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y" ignore_case="y" > </trigger>
 
-	<trigger match="^.+\w grazes +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w nicks +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w scars +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w hits +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w injures +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w wounds +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w mauls +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w maims +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w mangles +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w mars +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w LACERATES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w DECIMATES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w DEVASTATES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w ERADICATES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w OBLITERATES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w EXTIRPATES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w INCINERATES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w MUTILATES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w DISEMBOWELS +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w MASSACRES +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w DISMEMBERS +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w RENDS +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w - BLASTS - +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w -= DEMOLISHES =- +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w \*\* SHREDS \*\* +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w \*\*\*\* DESTROYS \*\*\*\* +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w \*\*\*\*\* PULVERIZES \*\*\*\*\* +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w -=- VAPORIZES -=- +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-==-> ATOMIZES <-==-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-:-> ASPHYXIATES <-:-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-\*-> RAVAGES <-\*-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <>\*<> FISSURES <>\*<> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <\*><\*> LIQUIDATES <\*><\*> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <\*><\*><\*> EVAPORATES <\*><\*><\*> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-=-> SUNDERS <-=-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <=-=><=-=> TEARS INTO <=-=><=-=> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <->\*<=> WASTES <=>\*<-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-\+-><-\*-> CREMATES <-\*-><-\+-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <\*><\*><\*><\*> ANNIHILATES <\*><\*><\*><\*> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <--\*--><--\*--> IMPLODES <--\*--><--\*--> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-><-=-><-> EXTERMINATES <-><-=-><-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-==-><-==-> SHATTERS <-==-><-==-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <\*><-:-><\*> SLAUGHTERS <\*><-:-><\*> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-\*-><-><-\*-> RUPTURES <-\*-><-><-\*-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-\*-><\*><-\*-> NUKES <-\*-><\*><-\*-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w -<\[=-\+-=\]<:::<>:::> GLACIATES <:::<>:::>\[=-\+-=\]>- +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-=-><-:-\*-:-><\*--\*> METEORITES <\*--\*><-:-\*-:-><-=-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w <-:-><-:-\*-:-><-\*-> SUPERNOVAS <-\*-><-:-\*-:-><-:-> +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w does UN\w+ things to +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w damages? +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +shreds +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +destroys +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +pulverizes +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +vaporizes +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +atomizes +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +asphyxiates +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +ravages +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +fissures +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +liquidates +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +evaporates +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +sunders +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +into +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +wastes +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +cremates +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +annihilates +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +implodes +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +exterminates +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +shatters +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +slaughters +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +ruptures +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +nukes +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +glaciates +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +meteorites +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
-
-	<trigger match="^.+\w +supernovas +(?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
+	<trigger match="^\*?(?:\[\d+\] )?Your \w+ (?:- BLASTS -|-= DEMOLISHES =-|\*\* SHREDS \*\*|\*\*\*\* DESTROYS \*\*\*\*|\*\*\*\*\* PULVERIZES \*\*\*\*\*|-=- VAPORIZES -=-|<-==-> ATOMIZES <-==->|<-:-> ASPHYXIATES <-:->|<-\*-> RAVAGES <-\*->|<>\*<> FISSURES <>\*<>|<\*><\*> LIQUIDATES <\*><\*>|<\*><\*><\*> EVAPORATES <\*><\*><\*>|<-=-> SUNDERS <-=->|<=-=><=-=> TEARS INTO <=-=><=-=>|<->\*<=> WASTES <=>\*<->|<-\+-><-\*-> CREMATES <-\*-><-\+->|<\*><\*><\*><\*> ANNIHILATES <\*><\*><\*><\*>|<--\*--><--\*--> IMPLODES <--\*--><--\*-->|<-><-=-><-> EXTERMINATES <-><-=-><->|<-==-><-==-> SHATTERS <-==-><-==->|<\*><-:-><\*> SLAUGHTERS <\*><-:-><\*>|<-\*-><-><-\*-> RUPTURES <-\*-><-><-\*->|<-\*-><\*><-\*-> NUKES <-\*-><\*><-\*->|-<\[=-\+-=\]<:::<>:::> GLACIATES <:::<>:::>\[=-\+-=\]>-|	<-=-><-:-\*-:-><\*--\*> METEORITES <\*--\*><-:-\*-:-><-=->|<-:-><-:-\*-:-><-\*-> SUPERNOVAS <-\*-><-:-\*-:-><-:->) (?<mob_name>\S.*)[!\.] \[\d+\]$"
+		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 	<trigger match="^(?:You assassinate |You catch |You attempt to bury .* deep into |You lunge at)(?<mob_name>.*)(?: with cold efficiency\.| completely off-guard and inflict massive damage on .*\.|'s? back!|with a .*!)$"
-		script="trigger_damage_done" ignore_case="y"  enabled="y" regexp="y" sequence="1" keep_evaluating="y" omit_from_output="n" > </trigger>
+		script="trigger_damage_done" enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 <!-- Gquest operations -->
 	<!-- group: trg_gq -->

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -7511,7 +7511,7 @@ end
 </script>
 <triggers>
 +<!-- Receive xp -->
-	<trigger match="^You (?:don't )?receive \d+(?:\+\d+)* experience points?\."
+	<trigger match="^(?:You (?:don't )?receive \d+(?:\+\d+)* experience points?\.|That was a pointless no-experience kill!)$"
 		script="trigger_receive_xp" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 <!-- Damage triggers -->

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE muclient>
 <!-- Saved on Saturday, July 05, 2008, 4:46 PM -->
 <muclient>
-<plugin version="5.89" name="Search_and_Destroy" id="30000000537461726C696E67" date_written="2018-12-31 23:00:00" author="Crowley and Naricain" language="Lua" purpose="Find mobs faster." save_state="y" requires="4.90" >
+<plugin version="5.9" name="Search_and_Destroy" id="30000000537461726C696E67" date_written="2018-12-31 23:00:00" author="Crowley and Naricain" language="Lua" purpose="Safe, legal Search and Destroy" save_state="y" requires="4.90" >
 <description trim="n"> </description> </plugin>
 
 <!-- Isolinear intermatrix (utility module) -->
@@ -54,10 +54,14 @@
 				"You have now joined Global Quest # 4685. See 'help gquest' for available commands.", "You may win 2 more gquests at this level.", "You can be rewarded for 50 more kills this level."
 		]]--
 
+	
+	dofile (GetInfo(60) .. "aardwolf_colors.lua")
+	
 	require "movewindow"
 	require "serialize"
 	require "tprint"
-	require "wait"
+	--require "wait"
+	require "..\\worlds\\plugins\\~lua_sd\\starling_sd_mods"
 
 	json = require "json"
 
@@ -65,10 +69,6 @@
 
 	function ifc(condition, ctrue, cfalse)
 		if condition then return ctrue else return cfalse end
-	end
-
-	function mapFind(query)
-		return CallPlugin("b6eae87ccedd84f510b74714", "map_find_query", query)
 	end
 
 	mshow                           = {}
@@ -87,7 +87,14 @@
 	local plugin_id_gmcp_mapper		= "b6eae87ccedd84f510b74714"
 	local plugin_id_z_order 		= "462b665ecb569efbf261422f"
 	local plugin_id_soundpack 		= "23832d1089f727f5f34abad8"
+	local pid = {	gmcp 	= "3e7dedbe37e44942dd46d264",
+					mapper 	= "b6eae87ccedd84f510b74714",
+					sound 	= "23832d1089f727f5f34abad8",
+					zord 	= "462b665ecb569efbf261422f" 	}
 
+	function mapFind(query)
+		return CallPlugin("b6eae87ccedd84f510b74714", "map_find_query", query)
+	end
 	local plugins_folder = GetPluginInfo(GetPluginID(), 20)
 	local db_file_1
 	local db_file_2
@@ -282,7 +289,7 @@
 	TEXT_COLOR_DETAILS = {
 		{ key = "normal",			default = "#E0E0E0", menu_name = "Normal mobs",
 			desc = "normal mobs" },
-		{ key = "targeted",			default = "#FF4000", menu_name = "Targeted mob",
+		{ key = "targeted",			default = "#FF6000", menu_name = "Targeted mob",
 			desc = "the currently targeted mob"},
 		{ key = "dead",				default = "#484848", menu_name = "Dead mobs",
 			desc = "a dead mobs" },
@@ -357,7 +364,7 @@
 
 --	[[ Plugin broadcast/receive process ]]
 	function OnPluginBroadcast(msg, id, name, text)
-		if (id == plugin_id_gmcp_handler) then
+		if (id == pid.gmcp) then
 			if (text == "char.status") then		-- character status
 				current_character_state = gmcp("char.status.state")
 			elseif (text == "room.info") then	-- current/previous room info
@@ -373,11 +380,11 @@
 						going_to_room = nil
 					end
 
-					if (#room_history == 300) then
-						room_history[300] = nil
+					if (#room_history == 501) then
+						room_history[501] = nil
 					end
 					table.insert(room_history, 1, room_history[0])
-					room_history[0] = { rmid = current_room.rmid, arid=current_room.arid }
+					room_history[0] = { rmid = current_room.rmid, arid=current_room.arid, name = current_room.name }
 				end
 
 			elseif (text == "comm.quest") then	-- quest info
@@ -410,11 +417,23 @@
 		get_changelog(false)
 	end
 
+	function OnPluginEnable()
+		InfoNote("Enabled ", "Search and Destroy")
+		win_init = false
+		xg_create_window()
+	end
+
+	function OnPluginDisable()
+		InfoNote("Disabled ", "Search and Destroy")
+		WindowDelete(win)
+	end
+
 	function migrate_database()
 		local db = sqlite3.open(GetInfo(66) .. "/SnDdb.db")
 		local current_version
 
 		create_initial_tables(db)
+		write_marks_to_db(db)
 
 		for row in db:nrows("PRAGMA user_version") do
 			current_version = row.user_version
@@ -551,6 +570,21 @@
 		db:execute([[
 			DELETE FROM mobs WHERE mob LIKE "%(wounded)%" OR mob LIKE "%(aimed)%";
 		]])
+	end
+
+	function write_marks_to_db(db)
+		DebugNote("writing start rooms to db")
+		load_area_start_rooms()
+		operations = {}
+		for arid, details in pairs(area_start_rooms) do
+			table.insert(operations, string.format([[
+				UPDATE area SET startRoom = %s
+				WHERE key = %s;
+			]],
+			fixsql(details.roomid),
+			fixsql(arid)))
+		end
+		execute_in_transaction(db, operations)
 	end
 
 	function get_changelog(all_changes)
@@ -832,7 +866,7 @@
 		["longnight"] 	= { start = "26367" },
 		["losttime"] 	= { start = "28584" },
 		["lowlands"] 	= { start = "28044" },
-		["lplanes"] 	= { start = "29364" },
+		["lplanes"] 	= { start = "29364" },	-- start room for lplanes is amulet portal destination.
 		["maelstrom"] 	= { start = "38058" },		-- M --
 		["manor"] 		= { start = "10621" },
 		["masq"] 		= { start = "29840" },
@@ -915,7 +949,7 @@
 		["tombs"] 		= { start = "15385" },
 		["umari"] 		= { start = "36601" },		-- U --
 		["underdark"] 	= { start = "27341" },
-		["uplanes"] 	= { start = "29364" },
+		["uplanes"] 	= { start = "29364" },	-- start room for uplanes is amulet portal destination
 		["uprising"] 	= { start = "15382" },
 		["vale"] 		= { start =  "1036" },		-- V --
 		["verdure"] 	= { start = "24090" },
@@ -1274,7 +1308,69 @@
 		["Yggdrasil: The World Tree"] 			= "ygg",
 		["Zangar's Demonic Grotto"] 			= "zangar" }
 
--- 	[[ Lookup table: Game calendar data]]
+-- [[ Amulet of the Planes mobs]]
+	local amplanes = {
+		["lplanes"] = { 
+			["a bariaur"] 				= "236",	-- pool 1, Gladsheim
+			["a cleric einheriar"] 		= "236",
+			["a mage einheriar"] 		= "236",
+			["a paladin einheriar"] 	= "236",
+			["a per"] 					= "236",
+			["a psionic einheriar"]		= "236",
+			["a ranger einheriar"] 		= "236",
+			["a thief einheriar"]		= "236",
+			["a titan"] 				= "236",
+			["a warrior einheriar"] 	= "236",
+			["a larva"] 				= "251",	-- pool 2, Pandemonium
+			["a malelephant"] 			= "251",
+			["a nightmare"] 			= "251",
+			["a hordling"] 				= "266",	-- pool 3, Hades
+			["a night hag"] 			= "266",
+			["a yagnoloth"] 			= "266",
+			--["a Dergholoth"] 			= "281",	-- pool 4, Gehenna
+			--["a Hydroloth"] 			= "281",
+			--["a Mezzoloth"] 			= "281",
+			--["a Nycaloth"] 				= "281",
+			--["a Psicloth"] 				= "281",
+			["a vaporighu"] 			= "281",
+			["an Arcanaloth"] 			= "281", 
+			--["an Ultroloth"] 			= "281",
+			["the General of Gehenna"]	= "281",
+			["a Dergholoth"] 			= "301",	-- pool 5, Acheron
+			["a Hydroloth"] 			= "301",
+			["a Mezzoloth"] 			= "301",
+			["a Nycaloth"] 				= "301",
+			["a Psicloth"] 				= "301",
+			["an Ultroloth"] 			= "301"		},
+		["uplanes"] = { 
+			["a monadic deva"] 			= "10870",	-- pool 6, Twin Paradise
+			["an adamantite dragon"]	= "10870",
+			["an air sentinel"]			= "10870",
+			["a t'uen-rin"] 			= "10820",	-- pool 7, Arcadia
+			["a translator"] 			= "10820",
+			["an agathinon aasimon"]	= "10820",
+			["an astral deva"] 			= "10820",
+			["a hound archon"] 			= "10835",	-- pool 8, Seven Heavens
+			["a lantern archon"] 		= "10835",
+			["a noctral"] 				= "10835",
+			["a planetar aasimon"] 		= "10835",
+			["a sword archon"] 			= "10835",
+			["a tome archon"] 			= "10835",
+			["a warden archon"] 		= "10835",
+			["a zoveri"] 				= "10835",
+			["a balanea"] 				= "10890",	-- pool 10, Elysium
+			["a light aasimon"] 		= "10890",
+			["a moon dog"] 				= "10890",
+			["a movanic deva"] 			= "10890",
+			["a phoenix"] 				= "10890",
+			["a solar aasimon"] 		= "10890",
+			["a mortai"] 				= "10910",	-- pool 11, Beastlands
+			["a warden beast"] 			= "10910",
+			["an animal lord"] 			= "10910",
+			["an animal spirit"] 		= "10910"	} }
+
+
+-- 	[[ Lookup table: Game calendar data ]]
 	local gCalendar = { }
 
 --	[[ Load saved table data ]]
@@ -1899,7 +1995,11 @@ end
 				InfoNote("room: ", qt.room)
 			end
 		end
-		search_rooms_exact(qt.room, qt.arid, qt.mob)
+		if (qt.arid == "lplanes" or qt.arid == "uplanes") then
+			xrun_to(qt.arid, true)
+		else
+			search_rooms_exact(qt.room, qt.arid, qt.mob)
+		end
 	end
 
 	function quest_status_gmcp(q)	-- sets quest status when you take a new quest, kill qmob, complete quest, etc.
@@ -1967,8 +2067,6 @@ end
 	end
 
 	function cp_info_level_taken(name, line, wildcards)
-		--local x = tonumber(wildcards.level)
-		--cp_info_level = x
 		cp_info_level = tonumber(wildcards.level)
 		set_variable("mcvar_cp_level_taken", cp_info_level)
 	end
@@ -2015,9 +2113,6 @@ end
 		player_is_on_cp()
 		can_get_new_cp = "no"
 		cp_info_level = tonumber(gmcp("char.status.level"))
-		--local x = tonumber(gmcp("char.status.level"))
-		--cp_info_level = x
-		
 		xg_draw_window()
 		if (noexp_onoff == "on") and (anex_tnl_cutoff > 0) then
 			InfoNote("Search and Destroy: Turning 'noexp' OFF (you have started a new CP)")
@@ -2227,13 +2322,9 @@ end
 			set_variable("mcvar_gqid_joined", gqid_joined)
 			set_variable("mcvar_gqid_started", gqid_started)
 			set_variable("mcvar_gqid_extended", gqid_extended)
-
 			gq_info_efflvl = potential_gq.efflvl
 			set_variable("mcvar_gq_info_efflvl", gq_info_efflvl)
-
 			area_room_type = area_room_type_check(gq_info_list)
-
-			-- cp_info_level = tonumber(gmcp("char.status.level"))	-- room target builder will crash without a sensible value here.  Just use current player level.
 			DebugNote("gq type detection: ", area_room_type, " (level ", gq_info_efflvl, ")")
 			xg_draw_window()
 			DoAfterSpecial(0.1, "do_gq_check()", sendto.script)
@@ -2246,7 +2337,7 @@ end
 	function do_gq_check()
 		player_is_on_gq()
 		local time_check = os.clock()					-- prevent double cp checks from different plugins
-		if ((time_check - last_cp_check) < 1.0) then
+		if ((time_check - last_gq_check) < 1.0) then
 			return
 		end
 		last_gq_check = time_check
@@ -2304,7 +2395,7 @@ end
 		if location then
 			location = Trim(location)
 			location = location:sub(2, #location-1)
-			if location:match(" - Dead$") then
+			if location:match(" %- Dead$") then
 				location = location:sub(1, #location - 7)
 				dead = "yes"
 			end
@@ -2489,8 +2580,6 @@ end
 		if (player_on_cp == "yes") then
 			DoAfterSpecial(0.4, [[ InfoNote("Reloading your cp targets....")
 								do_cp_info() ]], sendto.script)
-		else
-			EnableTriggerGroup("damage_message_triggers", false)
 		end
 	end
 
@@ -2976,11 +3065,14 @@ end
 							InfoNote("Xcp action is off - no additional action\n")
 						end
 						if (ri.arid ~= t.arid) then	-- if you're not in target area, xrunto target area.
-							--Execute("xrt " .. t.arid)
 							xrun_to(t.arid, true)
 						end
 					else	-- Room cp:  get target room from mapper, but don't move yet.  "go" takes you to room.
-						search_rooms_exact(t.roomName, t.arid, t.mob)
+						if (qt.arid == "lplanes" or qt.arid == "uplanes") then
+							xrun_to(qt.arid, true)
+						else
+							search_rooms_exact(t.roomName, t.arid, t.mob)
+						end
 					end
 				else
 					InfoNote(string.format("\nYou can't run there while you're %s!\n", character_state_string()))
@@ -3062,8 +3154,8 @@ end
 		local rmid = rmid
 		local arid = arid or getAreaFromRoomId(rmid)
 		if (is_vidblain_area(rmid) == true) then -- if target is in a vidblain area,
-			if(is_vidblain_area(ri.rmid) == false) then	-- but if you are not
-				vidblain_nav(rmid, arid)
+			if(is_vidblain_area(ri.rmid) == false) then	-- but you are not,
+				vidblain_nav(rmid, arid)	-- run vidblain navigation, UNLESS it's turned off OR player level is at or above the 'xset vidblain level' setting (allows use of portals to vidblain areas)
 			else
 				do_mapper_goto(rmid, "walk")
 			end
@@ -3189,7 +3281,7 @@ end
 					vidblain_nav_tbl = { i=0, j=0, rmid="", arid="", stat=1 }
 				end
 			else  -- arrived in vidblain proper
-				if (ch_state == "3") and (ch_state == vnt.stat) then  -- monitor char state for 3 ticks, if stable, start EIA timer and run to target area
+				if (ch_state == "3") and (ch_state == vnt.stat) then  -- monitor char state for 2 ticks, if stable, start EIA timer and run to target area
 					vnt.j = vnt.j + 1
 					if (vnt.j > 2) then
 						EnableTimer("vidblain_nav_timer", false) -- stop vidblain timer
@@ -3598,6 +3690,8 @@ end
 			WHERE name = %s AND area = %s
 			ORDER BY area
 		]] ,fixsql(room), fixsql(arid))
+
+			
 		search_rooms(select, mob_name)
 	end
 
@@ -3746,7 +3840,7 @@ end
 
 			if v.notes then
 				if show_notes_in_table() then
-					text = ellipsify(v.notes, note_width)
+					text = ellipsify(strip_colours(v.notes), note_width)
 				else
 					text = "[notes]"
 				end
@@ -4068,6 +4162,13 @@ end
 		end
 		local serial = serialize.save_simple(area_start_rooms)
 		set_variable("mcvar_areaStartRooms", serial)
+
+		local db = assert(sqlite3.open(snd_db_file))
+		operation = string.format("UPDATE area SET startRoom = %s WHERE key = %s;",
+			fixsql(ri.rmid), fixsql(ri.arid))
+		db:exec(operation)
+		db:close_vm()
+
 		InfoNote("\nxset mark: Room ", ri.rmid, " set as start of area ", ri.arid, ".\n")
 	end
 
@@ -4090,7 +4191,11 @@ end
 		end
 		start_room_type = "default"						-- If 'xset mark' isn't set, look up start room from the table areaDefaultStartRooms.
 		if areaDefaultStartRooms[arid] then 	-- Note, Upper/Lower Planes have the same default room.  More development needed here.
-			return areaDefaultStartRooms[arid].start		-- exact match on area id
+			if (exact == true) and (arid == "lplanes" or arid == "uplanes") then
+				return amplanes[arid][current_target.name]
+			else
+				return areaDefaultStartRooms[arid].start		-- exact match on area id
+			end
 		end
 		for k,v in pairs (areaDefaultStartRooms) do
 			if k:lower() == arid then -- exact match
@@ -4149,10 +4254,8 @@ end
 	local is_vidblain_area_sql = "SELECT area FROM rooms WHERE uid = %s "
 
 	function is_vidblain_area(roomid)
-		local level = tier_level()--tonumber(gmcp("char.status.level")) + 10 * tonumber(gmcp("char.base.tier"))
+		local level = tier_level()
 		if (xset_vidblain_onoff == "on") and (level < xset_vidblain_level) then
-			--local worldPath = GetInfo(66) .. Trim(sanitize_filename(WorldName()))
-			--local db = assert(sqlite3.open(worldPath .. ".db"))
 			local db = assert(sqlite3.open(mapper_db_file))
 			local select = string.format (is_vidblain_area_sql, fixsql(roomid))
 			local ar
@@ -4683,12 +4786,17 @@ end
 		for row in db:nrows(sql) do
 			found_notes = true
 			if (text_only == true) then
-				local line = string.format("    note:'%s'", row.notes)
+				local line = string.format("    note:'%s'", strip_colours(row.notes))
 				Hyperlink("xmapper move " .. row.uid, line, "go to room " .. row.uid, "lightblue", "black", 0, 1)
 			else
 				local line = string.format("    (%s) %s", row.uid, row.notes)
-				Hyperlink("xmapper move " .. row.uid, line, "go to room " .. row.uid, "lightblue", "black", 0, 1)
+				local styles = ColoursToStyles(line, ColourNameToRGB("lightblue"), ColourNameToRGB("black"), 0, 0)
+				
+				for _,style in pairs(styles[1]) do
+					Hyperlink("xmapper move " .. row.uid, style.text, "go to room " .. row.uid, RGBColourToName(style.textcolour), RGBColourToName(style.backcolour), 0, 1)
+				end
 			end
+
 			print("")
 		end
 		db:close_vm()
@@ -4861,8 +4969,8 @@ end
 			if (win_state == "min") then
 				mouseup_drag(0, "hsMinimize")
 			end
-			if (IsPluginInstalled(plugin_id_z_order) and GetPluginInfo(plugin_id_z_order, 17)) then
-				CallPlugin(plugin_id_z_order, "registerMiniwindow", win)
+			if (IsPluginInstalled(pid.zord) and GetPluginInfo(pid.zord, 17)) then
+				CallPlugin(pid.zord, "registerMiniwindow", win)
 			end
 			xg_draw_window()
 		end
@@ -5589,9 +5697,9 @@ end
 			xg_draw_window()
 			InfoNote("Window font changed to ", string.format("%s Size %i (%s)", win_font, win_font_size, new_font.style))
 		elseif (result == "Bring To Front") then
-			CallPlugin(plugin_id_z_order,"boostMe", win)
+			CallPlugin(pid.zord,"boostMe", win)
 		elseif (result == "Send To Back") then
-			CallPlugin(plugin_id_z_order,"dropMe", win)
+			CallPlugin(pid.zord,"dropMe", win)
 		elseif (result == "Collapse Window") then
 			win_state = "min"
 			win_height = win_height_min
@@ -5777,13 +5885,13 @@ end
 	end
 
 	function gmcp(s)
-	local ret, datastring = CallPlugin(plugin_id_gmcp_handler, "gmcpdata_as_string", s)
+	local ret, datastring = CallPlugin(pid.gmcp, "gmcpdata_as_string", s)
 	pcall(loadstring("data = "..datastring))
 	return data
 	end
 
 	function send_gmcp_packet(s)
-	CallPlugin(plugin_id_gmcp_handler, "Send_GMCP_Packet", s)
+	CallPlugin(pid.gmcp, "Send_GMCP_Packet", s)
 	end
 
 	function int(n)
@@ -5860,10 +5968,15 @@ end
 
 -- [[ Random stuff that doesn't fit anywhere else (?) ]]
 	function xtest_roomhist()
-		ColourNote("#00FFFF", "", "\ni: 0    r: " .. string.format("%-5s", room_history[0].rmid) .. "  a: " .. room_history[0].arid)
-		for i,v in ipairs (room_history) do
-			print("i: " .. string.format("%-3s", i) .. "  r: " .. string.format("%-5s", v.rmid) .. "  a: " .. string.format("%-10s", v.arid))
+		local rh = room_history
+		--ColourNote("#00FFFF", "", "\ni: 0    r: " .. string.format("%-5s", rh[0].rmid) .. "  a: " .. rh[0].arid)
+		--for i,v in ipairs (room_history) do
+		--	print("i: " .. string.format("%-3s", i) .. "  r: " .. string.format("%-5s", v.rmid) .. "  a: " .. string.format("%-10s", v.arid))
+		--end
+		for i=#rh,1,-1 do
+			print(" " .. string.format("%3s", i) .. "   r: " .. string.format("%-5s", rh[i].rmid) .. "  a: " .. string.format("%-10s", rh[i].arid) .. "     " .. rh[i].name)
 		end
+		ColourNote("#00FFFF", "", "   0   r: " .. string.format("%-5s", rh[0].rmid) .. "  a: " .. string.format("%-10s", rh[0].arid) .. "     " .. rh[0].name)
 		print("")
 	end
 
@@ -6111,7 +6224,7 @@ end
 			if upstream_version ~= tostring(PLUGIN_VERSION) then
 				callback(upstream_version)
 			elseif log_no_updates then
-				InfoNote("Search & Destroy: No new updates are currently available.")
+				InfoNote("Search & Destroy: No new updates available.")
 			end
 		end
 	end
@@ -6271,7 +6384,7 @@ end
 			"roomnote",
 			"qw",
 			"ht",
-			"ah",
+			"ah|aha",
 			"ak|kk|qk",
 			"qs",
 			"xq",
@@ -6397,7 +6510,7 @@ end
 			Note()
 			ColourNote("antiquewhite", "", unpack({helpWrap("Executes the 'hunt trick' for the current campaign target or supplied argument. Use 'stop' to stop the hunt trick, which will work in most cases but may fail if a mob has a keyword of 'stop'.")}))
 
-		elseif str == "ah" then
+		elseif str == "ah" or str == "aha" then
 			ColourNote("yellow", "", "Syntax", "antiquewhite", "", ": ah<a> <mobname>")
 			Note()
 			ColourNote("antiquewhite", "", unpack({helpWrap("Automatically sends the 'hunt' command and executes the direction hunt leads you. Append 'a' in order to abort autohunting. This is useful for tracking quest mobs through mazes, or if you really want to, hunting players. However, you must have hunt practiced for it to work.")}))
@@ -7099,8 +7212,8 @@ end
 
 	function play_target_found_sound()
 		DebugNote("Play target found here sound")
-		if is_sound_enabled() and IsPluginInstalled(plugin_id_soundpack) and GetPluginInfo(plugin_id_soundpack, 17) then
-			CallPlugin(plugin_id_soundpack, "TriggerEvent", "quest_target_found")
+		if is_sound_enabled() and IsPluginInstalled(pid.sound) and GetPluginInfo(pid.sound, 17) then
+			CallPlugin(pid.sound, "TriggerEvent", "quest_target_found")
 		end
 	end
 
@@ -7439,7 +7552,7 @@ end
 		"(?<mob_name>.+?) would crush you like a bug!$",
 		"(?<mob_name>.+?) would dance on your grave!$",
 		"(?<mob_name>.+?) says 'BEGONE FROM MY SIGHT unworthy\\!'$",
-		"You would be completely annihilated by (?<mob_name>.+?)!$"	}
+		"You would be completely annihilated by (?<mob_name>.+?)!$"		}
 
 	function setup_scan_con_triggers()
 		local flags_string = "(?<flags>(?: ?\\[AFK\\]| ?\\((?:" .. table.concat(SCAN_FLAGS, "|") .. ")\\))*)?"
@@ -7460,7 +7573,7 @@ end
 			SetTriggerOption(name, "group", "consider")
 		end
 	end
-	
+
 	function trigger_receive_xp()
 		if last_mob_damaged then
 			DebugNote("I suspect you just killed ", last_mob_damaged, " in room ", current_room.rmid, " (", current_room.arid, ")")
@@ -7470,13 +7583,13 @@ end
 		end
 		last_mob_damaged = nil
 	end
-
 	function trigger_damage_done(name, line, wildcards)
 		last_mob_damaged = Trim(wildcards.mob_name)
-		--print(last_mob_damaged)
 	end
+	
 ]]>
 </script>
+
 <triggers>
 <!-- Last mob killed detecton - damage messages, receive exp -->
 	<trigger match="^(?:You (?:don't )?receive \d+(?:\+\d+)* experience points?\.|That was a pointless no-experience kill!)$"
@@ -7503,12 +7616,12 @@ end
 		script="trigger_damage_done"
 		name="trg_dmgmsg_full" group="damage_message_triggers"
 		enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
-
+	
 	<trigger match="^(?:You assassinate |You catch |You attempt to bury .* deep into |You lunge at)(?<mob_name>.*)(?: with cold efficiency\.| completely off-guard and inflict massive damage on .*\.|'s? back!|with a .*!)$"
 		script="trigger_damage_done"
 		name="trg_dmgmsg_skills" group="damage_message_triggers"
 		enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
-		
+
 <!-- Gquest operations -->
 	<!-- group: trg_gq -->
 	<trigger match="^Quest Name\.\.\.\.\.\.\.\.\.: \[ Global quest # (?<gq_id>\d{1,5}) \]$"
@@ -8322,7 +8435,7 @@ end
 			group="Mob_Database"
 			enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12" > </alias>
 
-	<alias 	match="^x?mgo(?:to)? (\d+)$"
+	<alias 	match="^xmgo(?:to)? (\d+)$"
 			script="mobGo"
 			enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12" > </alias>
 

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1967,9 +1967,10 @@ end
 	end
 
 	function cp_info_level_taken(name, line, wildcards)
-		local x = tonumber(wildcards.level)
-		cp_info_level = x
-		set_variable("mcvar_cp_level_taken", x)
+		--local x = tonumber(wildcards.level)
+		--cp_info_level = x
+		cp_info_level = tonumber(wildcards.level)
+		set_variable("mcvar_cp_level_taken", cp_info_level)
 	end
 
 	function cp_info_line(name, line, wildcards)
@@ -1978,8 +1979,7 @@ end
 	end
 
 	function cp_info_end()
-		player_on_cp = "yes"
-		current_activity = "cp"
+		player_is_on_cp()
 		local t = cp_info_list
 		area_room_type = area_room_type_check(t)
 		print("cp type detection: ".. area_room_type .." (level "..cp_info_level..")\n")
@@ -2005,30 +2005,31 @@ end
 	end
 
 	function cp_check_end(name, line, wildcards)
-		player_on_cp = "yes"
-		current_activity = "cp"
+		player_is_on_cp()
 		build_main_target_list("cp", area_room_type)
 		xcp_retry()
 	end
 
 --	[[ general cp status functions ]]
 	function player_start_new_cp()	-- called by line "good luck on your campaign" when starting new cp
-		player_on_cp = "yes"
+		player_is_on_cp()
 		can_get_new_cp = "no"
-		local x = tonumber(gmcp("char.status.level"))
-		cp_info_level = x
-		current_activity = "cp"
+		cp_info_level = tonumber(gmcp("char.status.level"))
+		--local x = tonumber(gmcp("char.status.level"))
+		--cp_info_level = x
+		
 		xg_draw_window()
 		if (noexp_onoff == "on") and (anex_tnl_cutoff > 0) then
 			InfoNote("Search and Destroy: Turning 'noexp' OFF (you have started a new CP)")
 			anex_set_noexp("off")
 		end
+		
 		do_cp_info()
 	end
 
 	function cp_mob_killed()
 		if current_activity ~= "gq" then
-			xcp_retry_stat = 1
+			xcp_retry_stat = 1	-- see function xcp_retry for explanation
 			qw_reset(false)
 			last_kill_index = get_last_kill_index()
 			if last_kill_index and main_target_list[last_kill_index] then
@@ -2086,6 +2087,8 @@ end
 
 	function player_is_on_cp()
 		player_on_cp = "yes"
+		current_activity = "cp"
+		EnableTriggerGroup("damage_message_triggers", true)
 	end
 
 	function do_cp_complete(name, line, wildcards)
@@ -2097,6 +2100,7 @@ end
 		DebugNote("Called player_not_on_cp")
 		player_on_cp = "no"
 		EnableTriggerGroup ("trg_campaign", false)
+		EnableTriggerGroup("damage_message_triggers", false)
 		cp_info_level = "0"
 		set_variable("mcvar_cp_level_taken", "0")
 		cp_info_list = {}
@@ -2211,7 +2215,6 @@ end
 
 	function gq_info_end()
 		EnableTriggerGroup("trg_gq_info", false)
-
 		if potential_gq.finished then
 			DebugNote("Looking at the info of a finished gq. No action needed")
 			return
@@ -2324,7 +2327,6 @@ end
 
 	function gq_check_end()
 		EnableTriggerGroup("trg_gq_check", false)
-
 		player_is_on_gq()
 		build_main_target_list("gq", area_room_type)
 		xcp_retry()
@@ -2453,6 +2455,7 @@ end
 
 	function player_is_on_gq()
 		EnableTriggerGroup("trg_gqmsg", true)
+		EnableTriggerGroup("damage_message_triggers", true)
 		player_on_gq = "yes"
 		current_activity = "gq"
 	end
@@ -2486,6 +2489,8 @@ end
 		if (player_on_cp == "yes") then
 			DoAfterSpecial(0.4, [[ InfoNote("Reloading your cp targets....")
 								do_cp_info() ]], sendto.script)
+		else
+			EnableTriggerGroup("damage_message_triggers", false)
 		end
 	end
 
@@ -7399,20 +7404,6 @@ end
 		SetVariable("mcvar_xset_table_width", table_width)
 	end
 
-	function trigger_receive_xp()
-		if last_mob_damaged then
-			DebugNote("I suspect you just killed ", last_mob_damaged, " in room ", current_room.rmid, " (", current_room.arid, ")")
-			last_mob_killed = last_mob_damaged
-		else
-			DebugNote("****** ", "I don't know which mob you just killed", " ******")
-		end
-		last_mob_damaged = nil
-	end
-
-	function trigger_damage_done(name, line, wildcards)
-		last_mob_damaged = Trim(wildcards.mob_name)
-	end
-
 	function set_variable(key, value)
 		SetVariable(key, value)
 		state_changed = true
@@ -7429,47 +7420,11 @@ end
 
 	local SCAN_FLAGS = {
 		-- Player flags
-		"P",
-		"Player",
-		"OPK",
-		"Linkdead",
-		"WANTED",
-		"HARDCORE",
-		"OPK",
-		"Linkdead",
-		"Raider",
-		"Traitor",
+		"P", "Player", "OPK", "Linkdead", "WANTED", "HARDCORE", "OPK", "Linkdead", "Raider", "Traitor",
 		-- Mob flags
-		"Animated",
-		"A",
-		"Angry",
-		"Charmed",
-		"C",
-		"Diseased",
-		"D",
-		"Golden Aura",
-		"G",
-		"Hidden",
-		"H",
-		"Invis",
-		"I",
-		"Marked",
-		"X",
-		"Red Aura",
-		"R",
-		"Stealth",
-		"S",
-		"Translucent",
-		"T",
-		"Undead",
-		"U",
-		"White Aura",
-		"W",
-		"wounded",
-		"aimed",
-		"Old",
-		"O",
-	}
+		"Animated", "A", "Angry", "Charmed", "C", "Diseased", "D", "Golden Aura", "G", "Hidden", "H",
+		"Invis", "I", "Marked", "X", "Red Aura", "R", "Stealth", "S", "Translucent", "T", "Undead", "U",
+		"White Aura", "W", "Wounded", "Aimed", "Old", "O" }
 
 	local CONSIDER_OUTCOMES = {
 		"You would stomp (?<mob_name>.+?) into the ground\\.$",
@@ -7484,8 +7439,7 @@ end
 		"(?<mob_name>.+?) would crush you like a bug!$",
 		"(?<mob_name>.+?) would dance on your grave!$",
 		"(?<mob_name>.+?) says 'BEGONE FROM MY SIGHT unworthy\\!'$",
-		"You would be completely annihilated by (?<mob_name>.+?)!$",
-	}
+		"You would be completely annihilated by (?<mob_name>.+?)!$"	}
 
 	function setup_scan_con_triggers()
 		local flags_string = "(?<flags>(?: ?\\[AFK\\]| ?\\((?:" .. table.concat(SCAN_FLAGS, "|") .. ")\\))*)?"
@@ -7506,30 +7460,55 @@ end
 			SetTriggerOption(name, "group", "consider")
 		end
 	end
+	
+	function trigger_receive_xp()
+		if last_mob_damaged then
+			DebugNote("I suspect you just killed ", last_mob_damaged, " in room ", current_room.rmid, " (", current_room.arid, ")")
+			last_mob_killed = last_mob_damaged
+		else
+			DebugNote("****** ", "I don't know which mob you just killed", " ******")
+		end
+		last_mob_damaged = nil
+	end
 
+	function trigger_damage_done(name, line, wildcards)
+		last_mob_damaged = Trim(wildcards.mob_name)
+		--print(last_mob_damaged)
+	end
 ]]>
 </script>
 <triggers>
-+<!-- Receive xp -->
+<!-- Last mob killed detecton - damage messages, receive exp -->
 	<trigger match="^(?:You (?:don't )?receive \d+(?:\+\d+)* experience points?\.|That was a pointless no-experience kill!)$"
-		script="trigger_receive_xp" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+		script="trigger_receive_xp"
+		name="trg_dmgmsg_rec_exp" group="damage_message_triggers"
+		enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
-<!-- Damage triggers -->
-<trigger match="^\*?(?:\[\d+\] )?Your [A-Za-z ]+ does UN(?:SPEAKABLE|THINKABLE|IMAGINABLE|BELIEVABLE) things to (?<mob_name>\S.*)! \[\d+\]$"
-		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+	<trigger match="^\*?(?:\[\d+\] )?Your [A-Za-z ]+ does UN(?:SPEAKABLE|THINKABLE|IMAGINABLE|BELIEVABLE) things to (?<mob_name>\S.*)! \[\d+\]$"
+		script="trigger_damage_done"
+		name="trg_dmgmsg_unspeakable" group="damage_message_triggers"
+		enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 	<trigger match="^\*?(?:\[\d+\] )?You damage (?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+		script="trigger_damage_done"
+		name="trg_dmgmsg_damage_5" group="damage_message_triggers"
+		enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 	<trigger match="^\*?(?:\[\d+\] )?Your [A-Za-z ]+ (?:damages|misses|tickles|bruises|scratches|grazes|nicks|scars|hits|injures|wounds|mauls|maims|mangles|mars|lacerates|decimates|devastates|eradicates|obliterates|extirpates|incinerates|mutilates|disembowels|massacres|dismembers|rends|blasts|demolishes|shreds|destroys|pulverizes|vaporizes|atomizes|asphyxiates|ravages|fissures|liquidates|evaporates|sunders|tears into|wastes|cremates|annihilates|implodes|exterminates|shatters|slaughters|ruptures|nukes|glaciates|meteorites|supernovas) (?<mob_name>\S.*)[!\.] \[\d+\]$"
-		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y" ignore_case="y" > </trigger>
+		script="trigger_damage_done"
+		name="trg_dmgmsg_basic" group="damage_message_triggers"
+		enabled="n" regexp="y" sequence="1" keep_evaluating="y" ignore_case="y" > </trigger>
 
 	<trigger match="^\*?(?:\[\d+\] )?Your [A-Za-z ]+ (?:- BLASTS -|-= DEMOLISHES =-|\*\* SHREDS \*\*|\*\*\*\* DESTROYS \*\*\*\*|\*\*\*\*\* PULVERIZES \*\*\*\*\*|-=- VAPORIZES -=-|<-==-> ATOMIZES <-==->|<-:-> ASPHYXIATES <-:->|<-\*-> RAVAGES <-\*->|<>\*<> FISSURES <>\*<>|<\*><\*> LIQUIDATES <\*><\*>|<\*><\*><\*> EVAPORATES <\*><\*><\*>|<-=-> SUNDERS <-=->|<=-=><=-=> TEARS INTO <=-=><=-=>|<->\*<=> WASTES <=>\*<->|<-\+-><-\*-> CREMATES <-\*-><-\+->|<\*><\*><\*><\*> ANNIHILATES <\*><\*><\*><\*>|<--\*--><--\*--> IMPLODES <--\*--><--\*-->|<-><-=-><-> EXTERMINATES <-><-=-><->|<-==-><-==-> SHATTERS <-==-><-==->|<\*><-:-><\*> SLAUGHTERS <\*><-:-><\*>|<-\*-><-><-\*-> RUPTURES <-\*-><-><-\*->|<-\*-><\*><-\*-> NUKES <-\*-><\*><-\*->|-<\[=-\+-=\]<:::<>:::> GLACIATES <:::<>:::>\[=-\+-=\]>-|	<-=-><-:-\*-:-><\*--\*> METEORITES <\*--\*><-:-\*-:-><-=->|<-:-><-:-\*-:-><-\*-> SUPERNOVAS <-\*-><-:-\*-:-><-:->) (?<mob_name>\S.*)! \[\d+\]$"
-		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+		script="trigger_damage_done"
+		name="trg_dmgmsg_full" group="damage_message_triggers"
+		enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 
 	<trigger match="^(?:You assassinate |You catch |You attempt to bury .* deep into |You lunge at)(?<mob_name>.*)(?: with cold efficiency\.| completely off-guard and inflict massive damage on .*\.|'s? back!|with a .*!)$"
-		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
-	
+		script="trigger_damage_done"
+		name="trg_dmgmsg_skills" group="damage_message_triggers"
+		enabled="n" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
+		
 <!-- Gquest operations -->
 	<!-- group: trg_gq -->
 	<trigger match="^Quest Name\.\.\.\.\.\.\.\.\.: \[ Global quest # (?<gq_id>\d{1,5}) \]$"

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -7530,9 +7530,6 @@ end
 	<trigger match="^(?:You assassinate |You catch |You attempt to bury .* deep into |You lunge at)(?<mob_name>.*)(?: with cold efficiency\.| completely off-guard and inflict massive damage on .*\.|'s? back!|with a .*!)$"
 		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
 	
-	<trigger match="^(?<mob_name>\S.*) is unaffected by your [A-Za-z ]+!$"
-		script="trigger_damage_done" enabled="y" regexp="y" sequence="1" keep_evaluating="y"> </trigger>
-	
 <!-- Gquest operations -->
 	<!-- group: trg_gq -->
 	<trigger match="^Quest Name\.\.\.\.\.\.\.\.\.: \[ Global quest # (?<gq_id>\d{1,5}) \]$"

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -3184,9 +3184,9 @@ end
 					vidblain_nav_tbl = { i=0, j=0, rmid="", arid="", stat=1 }
 				end
 			else  -- arrived in vidblain proper
-				if (ch_state == "2") and (ch_state == vnt.stat) then  -- monitor char state for 3 ticks, if stable, start EIA timer and run to target area
+				if (ch_state == "3") and (ch_state == vnt.stat) then  -- monitor char state for 3 ticks, if stable, start EIA timer and run to target area
 					vnt.j = vnt.j + 1
-					if (vnt.j > 3) then
+					if (vnt.j > 2) then
 						EnableTimer("vidblain_nav_timer", false) -- stop vidblain timer
 						do_mapper_goto(vnt.rmid, "walk")
 						execute_in_area(vnt.arid, eiat.f)	-- start EIA timer

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -3184,7 +3184,7 @@ end
 					vidblain_nav_tbl = { i=0, j=0, rmid="", arid="", stat=1 }
 				end
 			else  -- arrived in vidblain proper
-				if (ch_state == "3") and (ch_state == vnt.stat) then  -- monitor char state for 3 ticks, if stable, start EIA timer and run to target area
+				if (ch_state == "2") and (ch_state == vnt.stat) then  -- monitor char state for 3 ticks, if stable, start EIA timer and run to target area
 					vnt.j = vnt.j + 1
 					if (vnt.j > 3) then
 						EnableTimer("vidblain_nav_timer", false) -- stop vidblain timer

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE muclient>
 <!-- Saved on Saturday, July 05, 2008, 4:46 PM -->
 <muclient>
-<plugin version="5.9" name="Search_and_Destroy" id="30000000537461726C696E67" date_written="2018-12-31 23:00:00" author="Crowley and Naricain" language="Lua" purpose="Safe, legal Search and Destroy" save_state="y" requires="4.90" >
+<plugin version="5.9" name="Search_and_Destroy" id="30000000537461726C696E67" date_written="2018-12-31 23:00:00" author="Crowley and Naricain" language="Lua" purpose="Find quest, cp, gq mobs faster." save_state="y" requires="4.90" >
 <description trim="n"> </description> </plugin>
 
 <!-- Isolinear intermatrix (utility module) -->

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -7411,7 +7411,6 @@ end
 
 	function trigger_damage_done(name, line, wildcards)
 		last_mob_damaged = Trim(wildcards.mob_name)
-		print(last_mob_damaged)
 	end
 
 	function set_variable(key, value)


### PR DESCRIPTION
edit 7/31 - I added what I worked on since then, which was pretty much just that doing xcp to a upper/lower planes mob will run to the recallable room in the correct pool instead of taking you to the amulet of the planes portal drop.  This makes doing planes mobs a bit nicer.

So, what I did was combine the 40 triggers into 5 triggers. They seem to work like they should.

I also tightened up the pattern matching.  We only want them reacting to the player's own damage messages.  The original triggers were reacting to things they definitely shouldn't.  They would react to mobs hitting you, players in your room fighting and hitting other mobs or players, mobs hitting other mobs/players, you hitting yourself, and so on.  They would also react to invalid messages, e.g. "Someone's triggerjack does UNFUNNY things to your script!"

I have no idea if the combined triggers are more efficient than the 40 separate ones or not.  I think they would be, with the tighter pattern matching and not firing on combat messages that aren't yours?  Not sure.

Do you get cp mob credit if your groupie kills the mob?  From help campaign rules, it looks like you don't.  I pretty much never group though, so not sure.

Fixed typos and whatnot.  GUI buttons animate properly.  Vidblain navigation is slightly faster.

Let me know if there are any issues.

eta:  I just got a cp to kill the chimera in citadel, which is a pointless no experience kill, so added that message to the trigger for trigger_receive_xp.  Also I kinda want to make it turn off those damage triggers if player isn't on a cp or gq.

eta at 20:38 - the damage triggers turn on when on a cp or gq, and turn off when not.  Compacted some long tables to shorten the length of the file and make it easier to find stuff.  Seems to be working just fine.  Let me know.