### PR TITLE
Have roomnote handle notes that have embedded color codes

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -4684,10 +4684,9 @@ end
 				local line = string.format("    note:'%s'", strip_colours(row.notes))
 				Hyperlink("xmapper move " .. row.uid, line, "go to room " .. row.uid, "lightblue", "black", 0, 1)
 			else
-				local line = string.format("    (%s) ", row.uid)
-				Hyperlink("xmapper move " .. row.uid, line, "go to room " .. row.uid, "lightblue", "black", 0, 1)
+				local line = string.format("    (%s) %s", row.uid, row.notes)
+				local styles = ColoursToStyles(line, ColourNameToRGB("lightblue"), ColourNameToRGB("black"), 0, 0)
 				
-				local styles = ColoursToStyles(row.notes, ColourNameToRGB("lightblue"), ColourNameToRGB("black"), 0, 0)
 				for _,style in pairs(styles[1]) do
 					Hyperlink("xmapper move " .. row.uid, style.text, "go to room " .. row.uid, RGBColourToName(style.textcolour), RGBColourToName(style.backcolour), 0, 1)
 				end

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -54,6 +54,9 @@
 				"You have now joined Global Quest # 4685. See 'help gquest' for available commands.", "You may win 2 more gquests at this level.", "You can be rewarded for 50 more kills this level."
 		]]--
 
+	
+	dofile (GetInfo(60) .. "aardwolf_colors.lua")
+	
 	require "movewindow"
 	require "serialize"
 	require "tprint"
@@ -3741,7 +3744,7 @@ end
 
 			if v.notes then
 				if show_notes_in_table() then
-					text = ellipsify(v.notes, note_width)
+					text = ellipsify(strip_colours(v.notes), note_width)
 				else
 					text = "[notes]"
 				end
@@ -4678,12 +4681,18 @@ end
 		for row in db:nrows(sql) do
 			found_notes = true
 			if (text_only == true) then
-				local line = string.format("    note:'%s'", row.notes)
+				local line = string.format("    note:'%s'", strip_colours(row.notes))
 				Hyperlink("xmapper move " .. row.uid, line, "go to room " .. row.uid, "lightblue", "black", 0, 1)
 			else
-				local line = string.format("    (%s) %s", row.uid, row.notes)
+				local line = string.format("    (%s) ", row.uid)
 				Hyperlink("xmapper move " .. row.uid, line, "go to room " .. row.uid, "lightblue", "black", 0, 1)
+				
+				local styles = ColoursToStyles(row.notes, ColourNameToRGB("lightblue"), ColourNameToRGB("black"), 0, 0)
+				for _,style in pairs(styles[1]) do
+					Hyperlink("xmapper move " .. row.uid, style.text, "go to room " .. row.uid, RGBColourToName(style.textcolour), RGBColourToName(style.backcolour), 0, 1)
+				end
 			end
+
 			print("")
 		end
 		db:close_vm()


### PR DESCRIPTION
Snd was not playing nicely with embedded color codes in room notes.
![image](https://user-images.githubusercontent.com/87405930/125559449-99a8015d-686d-4670-8868-2dddf72c0db2.png)

I hacked together a quick solution for this using a helper method found in **aardwolf_colors**. I don't know how you guys do things here, and I'm not familiar with lua or mushclient in general (I also didn't do much testing >_>), but I figure that if ya'll wanted to add support for this in SnD, what I've done may suffice as a jumpstart to that.

![image](https://user-images.githubusercontent.com/87405930/125559663-f3c22ec1-474d-4f94-a8eb-89da9dbd4653.png)

Cheers!