### PR TITLE
update noexp trigger to work when there are multiple sources of additional xp

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -8075,7 +8075,7 @@ end
 		name="trg_anex_automatic_on"
 		enabled="y" regexp="y" sequence="100" keep_evaluating="y" > </trigger>
 
-	<trigger match="^You (?:don't )?receive (\d+)(?:\+\d+)? experience points?\.$"
+	<trigger match="^You (?:don't )?receive (\d+)(?:\+\d+)* experience points?\.$"
 		script="anex_mobdeath_xp1"
 		name="trg_anex_mobdeath_xp1"
 		enabled="y" regexp="y" sequence="100" keep_evaluating="y" send_to="12" > </trigger>


### PR DESCRIPTION
The trigger was not working with multiple sources of xp (e.g. opk and exprate)
![image](https://user-images.githubusercontent.com/87405930/127736649-a7dfd0a8-8073-4fcf-8414-119f85b1372e.png)
