### PR TITLE
Add the special argument start to the xrun command, which will run to the start of the current area.

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -3449,6 +3449,9 @@ function xrun_to(arid, exact)
     if (arid == "ft2") then
         arid = "ftii"
     end
+    if (arid == "start") then
+        arid = current_room.arid
+    end
     local rmid = get_start_room(arid, exact)
     if (rmid == "-1") then -- area has no start room defined.
         InfoNote("X-runto: No default start room is defined for area: " .. arid .. ".\n")


### PR DESCRIPTION
Example usage in lemdagor

```
The Storm Cruiser, Tempest
  The entrance to the Tempest is messed up completely.  The gangways
are destroyed, and there seems to be no way out.  What is going on?
All around you, the din of exotic weapon blasts, men and women
screaming in pain, tell of a sudden attack by Lem Dagor pirates.

[ Exits: east ]

Details about this room:
+---------------------------+
Name: The Storm Cruiser, Tempest
ID: 2009
Area: lemdagor
Terrain: inside
Info: 
Notes: 
Flags:
Exits: 
"e"="2008"
Exit locks: 
"e"="0"
Ignore exits mismatch: false
+---------------------------+
```

```
xrun start
```

```
X-runto: lemdagor, room ID: 1966 (default)

Going to: The Storm Cruiser, Tempest
run e2swsne2nw

... bunch of text ...

The Storm Cruiser, Tempest
  Yes indeed, you are now experiencing one of the many great adventures of the 
Storm Ships of Lem-Dagor. Of course this is the famous cruiser, Tempest, 
where your voyage begins. Look around, look at everything for a clue. There 
is a big sign for you to read.

[ Exits: east west ]

Details about this room:
+---------------------------+
Name: The Storm Cruiser, Tempest
ID: 1966
Area: lemdagor
Terrain: inside
Info: 
Notes: 
Flags:
Exits: 
"w"="3357"
"enter gangway"="2064"
"e"="1967"
Exit locks: 
"w"="0"
"enter gangway"="0"
"e"="0"
Ignore exits mismatch: false
+---------------------------+
```

