### PR TITLE
Fix undefined plevel reference in anex_can_get_new_cp

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -4287,7 +4287,7 @@ function anex_can_get_new_cp() -- called by line 'You may take campaign this lev
             else
                 if (noexp_onoff == "on") then
                     anex_set_noexp("off")
-                    InfoNote("\nSearch and Destroy: Turning noexp OFF (you have reached level ", plevel, ")")
+                    InfoNote("\nSearch and Destroy: Turning noexp OFF (you have reached level ", level, ")")
                 end
             end
         else -- feature is turned off, just show reminder


### PR DESCRIPTION
## Summary
Single-token fix: `plevel` → `level` on line 4290.

## Background
`anex_can_get_new_cp` references an undefined variable `plevel` when formatting the "you have reached level N" notification. Lua's `ipairs` in `print_alternating_note` stops at the nil, silently dropping the trailing `")"` from the message.

## Reference
The sibling function `anex_must_level_new_cp` (line 4315) correctly uses the local `level` variable. This change brings `anex_can_get_new_cp` in line.

## Trigger conditions
Only fires for level-200 players with `xset noexp` active when a new campaign becomes available — narrow path but real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)