### PR TITLE
Fix column alignment when long mob names get truncated

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -3125,7 +3125,7 @@ function ellipsify(str, max_length)
     if #str <= max_length then
         return str
     else
-        return str:sub(1, max_length - 1) .. "…"
+        return str:sub(1, max_length - 3) .. "..."
     end
 end
 


### PR DESCRIPTION
## Summary
`ellipsify` returned strings whose byte length exceeded the requested visual width by 2, breaking column alignment in the campaign target table when mob, room, or area names had to be truncated.

Closes #110.

## Root cause
The previous implementation appended the Unicode ellipsis `"…"`:

```lua
return str:sub(1, max_length - 1) .. "…"
```

`"…"` is stored as 3 UTF-8 bytes (`\xe2\x80\xa6`) but renders as a single visual column. Lua's `#` operator and `string.format("%-Ns", x)` are byte-based, not Unicode-aware, so a string truncated to "31 ASCII chars + …" returns 34 bytes while the caller asked for a 32-byte column. The `-` separator and every subsequent column then shift right by 2 — visible in the screenshot on #110, and easily reproducible with `xtest simulate cp area` (which already includes "Laurence, archangel of the sword and shield and other implements of war").

The same logic affects all 8 `ellipsify` call sites: `mob_text` (32 cols, 28 cols), `roomName` (27 cols, 27 cols), `location` (30 cols), `v.name` (38 cols), and `notes` (variable).

## Fix
Use ASCII `"..."` (3 bytes, 3 visual columns) and truncate to `max_length - 3` so the result is exactly `max_length` bytes and exactly `max_length` visual columns:

```lua
return str:sub(1, max_length - 3) .. "..."
```

No call-site changes are needed; every existing `string.format("%-Ns", ellipsify(s, N))` continues to work.

## Verification
Before — `xtest simulate cp area`, row 14: the `-` separator falls 2 columns left of where it should.
After — same command, row 14 lines up with rows 1–11 perfectly. Short names (no truncation needed) are unchanged.

## Trade-offs and alternatives considered

| Option | Result | Why not |
|---|---|---|
| **A — Switch to `"..."` (chosen)** | Bytes == visual == max_length. Single-function diff, no caller changes. | Aesthetic loss of the compact `"…"` glyph. |
| B — Keep `"…"`, truncate to `max - 3` | Bytes = max_length, visual = max_length - 2. | Truncated rows render with a 2-column visual gap before the next field, looks like missing data. |
| C — Keep `"…"`, add a `pad_visual()` helper, change all 8 callers | Bytes ≠ visual but columns aligned. | Larger surface area for review; future callers must remember to use the helper instead of `string.format`. |

I went with A as the smallest behaviour-preserving fix. Happy to switch to B or C if you'd prefer to keep the Unicode glyph — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)