### PR TITLE
Add 'ht find' to repeat the last successful hunt trick

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -186,6 +186,7 @@ local autoHuntData = {}
 
 -- [[ hunt trick ]]
 local ht = {index = 1, first_target = true}
+local ht_last_found  -- set by ht_complete, used by ht_find to repeat last successful hunt
 
 -- [[ quick where ]]
 local qw = {index = 1}
@@ -3794,6 +3795,9 @@ end
 function ht_complete(name, line, wildcards)
     EnableTriggerGroup("AutoHunt", false)
     local ix = ht.index or 1
+    if has_target() then
+        ht_last_found = {index = ix, keyword = current_target.keyword}
+    end
     if has_activity_target() then
         qw.index = ix
         qw_exact()
@@ -3822,6 +3826,19 @@ function ht_abort(name, line, wildcards)
     EnableTriggerGroup("HuntTrick", false)
     ht_reset()
     InfoNote("Search and Destroy:  Hunt trick cancelled.")
+end
+
+function ht_find()
+    if ht_last_found then
+        if ht_last_found.index == 1 then
+            Send(string.format("hunt %s", ht_last_found.keyword))
+        else
+            Send(string.format("hunt %d.%s", ht_last_found.index, ht_last_found.keyword))
+        end
+    else
+        InfoNote("\nSearch and Destroy: 'ht find' has no previous hunt to repeat.")
+        InfoNote("Run 'ht' or 'ht <mob>' first to find a target.\n")
+    end
 end
 
 -- [[ quick scan, quick kill ("kk") ]]
@@ -7313,7 +7330,7 @@ function onHelp(name, line, wildcards)
             )
         )
     elseif str == "ht" then
-        ColourNote("yellow", "", "Syntax", "antiquewhite", "", ": ht <mob|stop>")
+        ColourNote("yellow", "", "Syntax", "antiquewhite", "", ": ht <mob|stop|find>")
         Note()
         ColourNote(
             "antiquewhite",
@@ -7321,7 +7338,7 @@ function onHelp(name, line, wildcards)
             unpack(
                 {
                     helpWrap(
-                        "Executes the 'hunt trick' for the current campaign target or supplied argument. Use 'stop' to stop the hunt trick, which will work in most cases but may fail if a mob has a keyword of 'stop'."
+                        "Executes the 'hunt trick' for the current campaign target or supplied argument. Use 'stop' to stop the hunt trick, which will work in most cases but may fail if a mob has a keyword of 'stop'. Use 'find' to repeat the last successful hunt with the same index — useful for re-checking if your mob has moved into the current room without restarting the hunt sequence."
                     )
                 }
             )
@@ -9830,6 +9847,10 @@ end
 	<alias	match="^ht$"
 			script="ht_noarg"
 			enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12" > </alias>
+
+	<alias	match="^ht find$"
+			script="ht_find"
+			enabled="y" regexp="y" sequence="50" ignore_case="y" send_to="12" > </alias>
 
 	<alias	match="^ht (?:(?<index>\d+)\.)?(?<mob>.+)?$"
 			script="ht_arg"


### PR DESCRIPTION
## Summary
Adds `ht find` — a one-shot command that repeats the most recent successful hunt trick using the same `index.keyword` combination. Matches the behaviour of Pwar's `ht find` so users migrating from Pwar's plugin can use the same muscle memory.

Closes #69.

## Behaviour
- After `ht_complete` locates a target via `hunt N.keyword`, the index and keyword are stored in a session-scoped `ht_last_found` table.
- `ht find` sends that same `hunt N.kw` (or `hunt kw` when index is 1, matching `do_hunt_trick`'s convention).
- If there is no prior hunt this session, prints a friendly hint instead.
- State is cleared on plugin reload only — same scope as `ht.index` and `qw.index`.

## Diff outline
1. New local `ht_last_found` next to existing `ht` state.
2. `ht_complete` saves the current index/keyword before `ht_reset()` wipes `ht`.
3. New `ht_find()` function.
4. New `^ht find$` alias placed **before** the broader `^ht (?:...)$` alias, with `sequence="50"` so it wins regardless of MUSHclient's tie-break order. Without this guard, typing `ht find` would parse as `ht_arg` with `mob="find"` and try to hunt a mob named "find".
5. `xhelp ht` updated to document the new option.

## Trade-offs and alternatives considered

| Aspect | Choice | Alternatives |
|---|---|---|
| Command name | `ht find` (Pwar parity) | `htf`, `ht repeat`, `ht again` |
| State scope | Session-only | Persist via `mcvar_*` — extra complexity for marginal value, matches existing `ht`/`qw` state pattern |
| Auto-clear on target change | No | Yes — but would diverge from `qw.index` behaviour, and users may legitimately want to re-check old targets |
| Index-1 syntax | `hunt kw` (no `1.`) | Always `hunt N.kw` — chose to mirror `do_hunt_trick` line 3777-3781 for consistency |

Happy to revisit any of these if you'd prefer different defaults.

## Verification
- Cold `ht find` (no prior hunt) → prints "no previous hunt to repeat" hint. ✓
- `ht <mob>` succeeds → `ht find` from a different room re-sends the same hunt command. ✓
- `xhelp ht` shows the updated syntax line and description. ✓
- Existing `ht`, `ht <mob>`, `ht stop` still work. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)