### PR TITLE
Handle mid-word apostrophes and hyphens in auto-generated keywords

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1881,7 +1881,6 @@ function gmkw(s, a) -- guess mob keywords
     else
         s3 = s2
     end
-    s3 = string.gsub(s3, "-", " ")
 
     local s4 = {}
     for w in string.gmatch(s3, "[^ ]+") do
@@ -1890,15 +1889,20 @@ function gmkw(s, a) -- guess mob keywords
     local len1 = #(s4[1])
     local len2 = #(s4[#s4]) or 0
     -- Aardwolf's command parser can't match a truncated word containing a bare
-    -- apostrophe (e.g. "nulan'b" against "a Nulan'Boar mother"), so when a word
-    -- contains one we keep the full word rather than truncating. See issue #109.
+    -- apostrophe (e.g. "nulan'b" against "a Nulan'Boar mother") or a partial
+    -- hyphenated keyword (e.g. "yama uba" or "yamauba" against "a yama-uba").
+    -- When a word contains either character, keep the full word rather than
+    -- truncating. See issues #109 (apostrophes) and #125 (hyphens).
+    local function keep_full(w)
+        return w:find("'", 1, true) or w:find("-", 1, true)
+    end
     if (#s4 > 1) then -- mob name has multiple words
         local first, last = s4[1], s4[#s4]
-        local x = first:find("'", 1, true) and #first or math.random(4, 6)
-        local y = last:find("'", 1, true) and #last or math.random(4, 6)
+        local x = keep_full(first) and #first or math.random(4, 6)
+        local y = keep_full(last) and #last or math.random(4, 6)
         guess = string.sub(first, 1, x) .. " " .. string.sub(last, 1, y)
     elseif (#s4 == 1) then -- mob name has one word
-        if s4[1]:find("'", 1, true) then
+        if keep_full(s4[1]) then
             guess = s4[1]
         else
             local x = math.random(2 + round_banker(len1 * 0.5), len1)

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1889,12 +1889,21 @@ function gmkw(s, a) -- guess mob keywords
     end
     local len1 = #(s4[1])
     local len2 = #(s4[#s4]) or 0
+    -- Aardwolf's command parser can't match a truncated word containing a bare
+    -- apostrophe (e.g. "nulan'b" against "a Nulan'Boar mother"), so when a word
+    -- contains one we keep the full word rather than truncating. See issue #109.
     if (#s4 > 1) then -- mob name has multiple words
-        local x, y = math.random(4, 6), math.random(4, 6)
-        guess = string.sub(s4[1], 1, x) .. " " .. string.sub(s4[#s4], 1, y)
+        local first, last = s4[1], s4[#s4]
+        local x = first:find("'", 1, true) and #first or math.random(4, 6)
+        local y = last:find("'", 1, true) and #last or math.random(4, 6)
+        guess = string.sub(first, 1, x) .. " " .. string.sub(last, 1, y)
     elseif (#s4 == 1) then -- mob name has one word
-        local x = math.random(2 + round_banker(len1 * 0.5), len1)
-        guess = string.sub(s4[1], 1, x)
+        if s4[1]:find("'", 1, true) then
+            guess = s4[1]
+        else
+            local x = math.random(2 + round_banker(len1 * 0.5), len1)
+            guess = string.sub(s4[1], 1, x)
+        end
     else -- Sometimes all of the mob words get deleted, if so just use original input.  In theory, if we reached this step
         guess = s or "gmkw error in stage 4" -- then the input is non-nil and I've never seen it be "" ... so, if it errors it means Lua is propagating a nil
     end
@@ -4556,6 +4565,7 @@ function simulate_cp(name, line, wildcards)
         Simulate("You still have to kill * a hideously hairy spider (The Temple of Shouggoth)\n") -- nowhere
         Simulate("You still have to kill * Don Crumble (Zangar's Demonic Grotto)\n") -- nohunt
         Simulate("You still have to kill * A very large firefly (Kobold Siege Camp)\n") -- nohunt/nowhere
+        Simulate("You still have to kill * a Nulan'Boar mother (Plains of Nulan'Boar)\n") -- mid-word apostrophe, issue #109
     else
         Simulate("You still have to kill * red velvet (tm) lipstick (Skirting a Fissure)\n")
         Simulate("You still have to kill * a staggering barbegazi (Cell block A (Lower))\n")
@@ -4578,6 +4588,7 @@ function simulate_cp(name, line, wildcards)
             "You still have to kill * Laurence, archangel of the sword and shield and other implements of war (In the clouds)\n"
         ) -- long known
         Simulate("You still have to kill * a giant bee (An Impossibly Dark Intersection in the Labyrinth)\n") -- long room name
+        Simulate("You still have to kill * a Nulan'Boar mother (A small grassy paddock)\n") -- mid-word apostrophe, issue #109
     end
     Simulate("Note: Dead means that the target is dead, not that you have killed it.\n")
     Simulate("\n")


### PR DESCRIPTION
## Summary
Fixes `gmkw` for two related Aardwolf-significant punctuation characters that the keyword generator was mis-handling — apostrophes (`a Nulan'Boar mother`) and hyphens (`a yama-uba`). Both are the same class of bug: Aardwolf preserves these characters as part of the keyword and only matches keyword **prefixes**, so any plugin transformation (truncation mid-character, stripping, or replacement with a space) produces a keyword that no longer matches.

Closes #109 and #125.

## Root cause
`gmkw` truncates the first and last words of a mob name to 4-6 random characters. Two prior bugs in this block:
1. **Apostrophes:** `"a Nulan'Boar mother"` → `s4 = ["nulan'boar", "mother"]` → truncated to `"nulan'b mothe"`. Aardwolf rejects `nulan'b` — the bare apostrophe in a truncated word acts like an unclosed quote.
2. **Hyphens:** Before truncation, the helper ran `s3 = string.gsub(s3, "-", " ")`, replacing all hyphens with spaces. `"a yama-uba"` → `"yama uba"` → `s4 = ["yama", "uba"]` → keyword `"yama uba"` — sent to Aardwolf as a two-token kill where `uba` doesn't prefix-match any keyword on the mob.

Live-tested Aardwolf matching behaviour (in nulan and manor zones):

**Apostrophe class:**
| Form | Result |
|---|---|
| `con nulan'boar mother` | ✓ |
| `con nulanboar mother` | ✗ |
| `con nulan'b moth` | ✗ |
| `con nulan mother` | ✓ |

**Hyphen class:**
| Form | Result |
|---|---|
| `con yama-uba` | ✓ |
| `con yama uba` | ✗ |
| `con yamauba` | ✗ |
| `con yama` | ✓ (prefix) |
| `con uba` | ✗ (Aardwolf only matches keyword prefixes) |

Both characters must be preserved in full when building the keyword, otherwise targeting fails.

## Fix
Single code block in `gmkw`. Two changes:
1. Delete the `s3 = string.gsub(s3, "-", " ")` line.
2. Extend the "keep the full word" predicate to fire on either `'` or `-`. Both the multi-word and single-word truncation paths use a small local `keep_full(w)` helper.

No callers changed.

## Scope

**Apostrophes** (~100+ mobs across ~14 areas): nulan, callhero, deneria, insan, sirens, siege, sennarre, terramire, tol, underdark, uplanes, weather, woodelves.

**Hyphens** (~100+ mobs across ~25 areas): aardington, alehouse, andarin, annwn, ascent, aylor, bazaar, camps, cradle, dhalgora, fractured, hedge, hell, hoard, lab, labyrinth, lidnesh, manor, salt, sandcastle, sendhian, talsa, terramire, thieves, tilule, tirna, uplanes, wooble, zoo, etc.

**Combined apostrophe+hyphen mobs** (handled cleanly by the unified predicate): `t'uen-rin`, `will-o'-the-wisp`.

**NOT fixed, noted as follow-up:** the `elemental` area has a custom `gmkw_area_filter` that strips apostrophes *before* this code runs:
```lua
["elemental"] = {
    {f = "^(%a+)%'(%a+) (%a+)$", g = "%1%2 %3"},
    {f = "^wandering (%a+)%'(%a+) (%a+)$", g = "%1%2 %3"}
}
```
`dra'ork servant`, `wandering dra'ork alchemist`, etc. remain broken after this PR. Tracked in #120 — happy to follow up once a tester with elemental access can verify.

## Known Aardwolf-side quirk (unrelated but worth noting)
Even with a correctly-formed keyword, Aardwolf's parser can mis-disambiguate between same-family apostrophe/hyphen mobs. Reproducible without SnD: in a room containing `a Nulan'Boar mother`, `a Nulan'Boar girl`, and `a Nulan'Boar baby`, typing `kill nulan'boar baby` targets the mother instead of the baby. Server-side issue, not something SnD can work around from the keyword side. Flagging here so reviewers know the limit of this fix's behavioural win.

## Simulate fixtures
Added one `a Nulan'Boar mother` entry to each of the area-type and room-type `simulate_cp` Simulates so the fix is reachable via `xtest simulate cp area` / `xtest simulate cp room` without waiting for a natural campaign. Matches the pattern of the existing `gq_room_targets` test fixture.

## Verification
Live-tested in-game:
- `xtest simulate cp area`/`room` → target list renders cleanly, `xcp N` on the Nulan'Boar row → `ak` correctly targets the mother. ✓
- `xcp N` on `a yama-uba` in manor → `ak` correctly targets, no more "Nobody here" failure. ✓
- Short non-apostrophe non-hyphen mobs unchanged (random 4-6-char truncation preserved). ✓
- Plugin loads with no Lua errors on reload. ✓

## Trade-offs and alternatives considered

| Option | Result | Why not |
|---|---|---|
| **Keep apostrophe/hyphen word whole** (chosen) | Aardwolf matches correctly, minimal code change | Slightly longer keywords |
| Strip apostrophes/hyphens from keyword | Aardwolf rejects the stripped form (verified in-game for both) | Doesn't work |
| Truncate to before apostrophe/hyphen | Risk over-shortening short prefix words (e.g. `cha'tai` → `cha`) | Ambiguity risk |

🤖 Generated with [Claude Code](https://claude.com/claude-code)