### PR TITLE
Fix scan/consider regex dropping mobs with unknown flag characters

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -8991,8 +8991,11 @@ local SCAN_FLAGS = {
     "W",
     "wounded",
     "aimed",
+    "!",
     "Old",
-    "O"
+    "O",
+    "Flying",
+    "F"
 }
 
 local CONSIDER_OUTCOMES = {
@@ -9012,7 +9015,13 @@ local CONSIDER_OUTCOMES = {
 }
 
 function setup_scan_con_triggers()
-    local flags_string = "(?<flags>(?: ?\\[AFK\\]| ?\\((?:" .. table.concat(SCAN_FLAGS, "|") .. ")\\))*)?"
+    -- The paren group matches either a single uppercase letter (catch-all for any
+    -- current or future Aardwolf single-letter flag) or an explicit entry from
+    -- SCAN_FLAGS. Without the [A-Z] catch-all, any scan line containing a flag
+    -- not yet added to SCAN_FLAGS silently fails the regex and mobs in the line
+    -- never get their [CP]/[GQ]/[Q] activity tag. Multi-char names like "(Helper)"
+    -- remain safe because they match neither [A-Z]{1} nor the whitelist.
+    local flags_string = "(?<flags>(?: ?\\[AFK\\]| ?\\((?:[A-Z]|" .. table.concat(SCAN_FLAGS, "|") .. ")\\))*)?"
     local match = "^ {5}-" .. flags_string .. " (?<mob_name>.+)$"
     local name
 


### PR DESCRIPTION
## Summary
`scan_mob` and the `consider_*` triggers share a regex whose flag group is built from a hardcoded `SCAN_FLAGS` whitelist. When Aardwolf sends a flag character not in the whitelist, the whole regex fails to match, the trigger never fires, and the mob line flows to output without its `[CP]`/`[GQ]`/`[Q]` activity tag. Two real Aardwolf flags are currently missing: `(F)` Flying and `(!)` Aimed.

Closes #121.

## Root cause
```lua
local flags_string = "(?<flags>(?: ?\\[AFK\\]| ?\\((?:" .. table.concat(SCAN_FLAGS, "|") .. ")\\))*)?"
local match = "^ {5}-" .. flags_string .. " (?<mob_name>.+)$"
```

For input `     - (F)(R) A mist wraith`:
1. `^ {5}-` matches.
2. The flags group tries `(F)` — `F` not in the whitelist, zero flags consumed.
3. The regex then requires a literal space after the empty flags group; next character is `(`. Regex fails.
4. `omit_from_output` doesn't kick in, `scan_mob()` never runs, `mob_activity_tags()` never adds the `[CP]` prefix.

Per `help mobflags`, Aardwolf's canonical list is: `(!)` Aimed, `(R)/(G)` Align, `(A)` Animated, `(C)` Charmed, `(D)` Diseased, **`(F)` Flying**, `(H)` Hidden, `(I)` Invis, `(X)` Rune of Ix, `(O)` Old, `(T)` Passdoor, `(P)` Player, `(W)` Sanctuary, `(S)` Stealth, `(U)` Undead, `[AFK]`. `F` and `!` are missing from `SCAN_FLAGS`.

PR #63 (merged 2021) intentionally introduced the strict whitelist to keep mob-name parens like `(Helper) Fenix` from being misparsed as flags. That constraint is correct; the whitelist has just fallen behind Aardwolf's flag additions.

## Fix

Two layers, both in the same diff so reviewers can see the intent clearly:

1. **Add the missing explicit entries** — `"F"`, `"Flying"`, `"!"` — matching the existing `"P"/"Player"`, `"A"/"Animated"` pairing style so the list keeps doubling as documentation.

2. **Add `[A-Z]` as an alternative inside the paren group** alongside the whitelist, so any future single-letter Aardwolf flag is caught without a code change. `(Helper) Fenix` stays safe: "Helper" is 6 chars, matches neither `[A-Z]{1}` nor any whitelist entry.

End-state regex:
```
^ {5}-(?<flags>(?: ?\[AFK\]| ?\(([A-Z]|P|Player|...|F|Flying|!)\))*)? (?<mob_name>.+)$
```

## Verification
Live-tested in-game:

**Before the fix**, a flying CP target on scan:
```
Right here you see:
     - (F)(R) A mist wraith     ← no [CP] prefix
```

**After the fix**:
```
con
(F)(G) An older tungsten dragon whelp (+10 to +15)     ← not on CP, correctly untagged
[CP] (F)(G) An older chromium dragon whelp (+5 to +9)  ← on CP, correctly tagged
```

Non-flying mobs, `(Helper) Fenix`-style names, and AFK-bracketed players continue to render as before (no regression).

## Trade-offs considered

| Option | Result | Why not |
|---|---|---|
| **Explicit entries + `[A-Z]` catch-all (chosen)** | Fixes today's bug + future-proofs against new single-letter flags. Whitelist stays as documentation. | Slightly more surface area for review. |
| Explicit entries only (`"F"`, `"Flying"`, `"!"`) | Minimal diff, matches existing convention exactly | Regresses again the next time Aardwolf adds a letter. |
| Permissive `\([^)]+\)` | Simplest regex | Would re-break `(Helper) Fenix` — PR #63 specifically guarded against this. |

Happy to strip the `[A-Z]` broadening if you'd prefer to keep the whitelist strict — the first commit in isolation is a valid smaller fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)