### PR TITLE
Offer all candidate rooms for a named target, not just one

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -3499,12 +3499,25 @@ function xcp_goto_target(index)
             if is_character_ready() then
                 DebugNote("Character ready")
 				if is_express_target(t) then
-					next_room = t.roomid
-					table.insert(gotoList, 0, t.arid)
-					table.insert(gotoList, 1, t.roomid)
-					set_going_to_room(t.roomid)
-					goto_room_id(tostring(t.roomid), t.arid)
-					DebugNote("Attempting to go directly to an express target.")
+					-- Express: we already know room(s) for this mob from the DB.
+					-- List ALL of them best-bet first, then auto-go to #1; the
+					-- rest stay reachable via go 2..N / nx. Falls back to a direct
+					-- jump if (unexpectedly) no candidate rooms are found.
+					local n = search_rooms_by_mob(t.mob, t.arid)
+					if n and n > 0 then
+						if gotoList[1] then
+							set_going_to_room(gotoList[1])
+						end
+						Execute("go 1")
+						DebugNote("Express target: ", n, " candidate room(s), going to best.")
+					else
+						next_room = t.roomid
+						table.insert(gotoList, 0, t.arid)
+						table.insert(gotoList, 1, t.roomid)
+						set_going_to_room(t.roomid)
+						goto_room_id(tostring(t.roomid), t.arid)
+						DebugNote("Attempting to go directly to an express target.")
+					end
 				elseif (t.link_type == "area") then -- Area cp links - "xcp" goes to target area, then runs Hunt Trick to get target room.
                     if (action == "ht" and current_activity == "cp") then -- do hunt trick or quick where after arriving in area.
                         local func = function()
@@ -3523,8 +3536,15 @@ function xcp_goto_target(index)
                         --Execute("xrt " .. t.arid)
                         xrun_to(t.arid, true)
                     end
-                else -- Room cp:  get target room from mapper, but don't move yet.  "go" takes you to room.
-                    search_rooms_exact(t.roomName, t.arid, t.mob)
+                else -- Room cp:  get target room(s), but don't move yet.  "go" takes you to room.
+                    -- Prefer every room the mob is actually known to occupy (handles a
+                    -- mob living in several differently-named rooms, and avoids matching
+                    -- same-named rooms that don't contain it). Fall back to a mapper
+                    -- room-name search when the mob has never been recorded.
+                    local n = search_rooms_by_mob(t.mob, t.arid)
+                    if not n or n == 0 then
+                        search_rooms_exact(t.roomName, t.arid, t.mob)
+                    end
                 end
             else
                 InfoNote(string.format("\nYou can't run there while you're %s!\n", character_state_string()))
@@ -4208,6 +4228,84 @@ function xset_silentMode(name, line, wildcards)
 end
 
 -- [[ Room search processes ]]
+function search_rooms_by_mob(mob_name, arid)
+    -- Build the navigable room list from EVERY room the mob is known to occupy in
+    -- this zone (not just rooms that share one name), ranked best-bet first. This
+    -- is what lets a single named target that lives in several static rooms (e.g.
+    -- "Justice" across four different rooms in The Partroxis) be walked via
+    -- go 1 / go 2 / ... / nx. Returns the number of candidate rooms (0 if the mob
+    -- has never been recorded in this zone, so the caller can fall back).
+    if not mob_name or not arid or arid == "-1" then
+        return 0
+    end
+    local mob = normalize_mob_name(mob_name)
+    local SnDdb = assert(sqlite3.open(snd_db_file))
+    local rows = {}
+    local roomid_list = {}
+    local query =
+        string.format(
+        [[
+			SELECT roomid, room, seen_count, kill_count
+			FROM mobs
+			WHERE mob = %s AND zone = %s
+			ORDER BY kill_count DESC, seen_count DESC, roomid ASC;
+		]],
+        fixsql(mob),
+        fixsql(arid)
+    )
+    for row in SnDdb:nrows(query) do
+        table.insert(rows, row)
+        table.insert(roomid_list, tonumber(row.roomid))
+    end
+    SnDdb:close_vm()
+    if #rows == 0 then
+        return 0
+    end
+
+    -- Refresh room names/areas from the mapper (authoritative, current).
+    local namebyid = {}
+    local db = assert(sqlite3.open(mapper_db_file))
+    local mquery =
+        string.format("SELECT uid, name, area FROM rooms WHERE uid IN (%s);", table.concat(roomid_list, ","))
+    for r in db:nrows(mquery) do
+        namebyid[tonumber(r.uid)] = {name = r.name, area = r.area}
+    end
+    db:close_vm()
+
+    local sum = 0
+    for _, row in ipairs(rows) do
+        sum = sum + (tonumber(row.seen_count) or 0)
+    end
+
+    local results = {}
+    for _, row in ipairs(rows) do
+        local info = namebyid[tonumber(row.roomid)]
+        local seen = tonumber(row.seen_count) or 0
+        table.insert(
+            results,
+            {
+                rmid = tonumber(row.roomid),
+                name = (info and info.name) or row.room,
+                arid = (info and info.area) or arid,
+                seen_count = seen,
+                percentage = (sum > 0) and (seen / sum) or 0
+            }
+        )
+    end
+
+    -- Float any maze start rooms to the top (mirrors search_rooms()).
+    for k, v in ipairs(results) do
+        if mazeStartRooms[v.rmid] ~= nil then
+            local entry = table.remove(results, k)
+            entry.mz = "yes"
+            table.insert(results, 1, entry)
+        end
+    end
+
+    search_rooms_results(results)
+    return #results
+end
+
 function search_rooms_exact(room, arid, mob_name)
 	local select = ""
 	if ((arid == "soh") or (arid == "sohtwo")) then

--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -48,7 +48,7 @@ async_ok, async = pcall(require, "async")
 
 PLUGIN_VERSION = GetPluginInfo(GetPluginID(), 19)
 PLUGIN_NAME = GetPluginInfo(GetPluginID(), 1)
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 prevBeta = "5.9m"
 betaVersion = "5.9n"
@@ -74,7 +74,7 @@ showStr = "@W%s @wis found in @Y%s @win/around @G%s @w(@Cmapper goto %s@w)"
 
 PLUGIN_VERSION = GetPluginInfo(GetPluginID(), 19)
 PLUGIN_NAME = GetPluginInfo(GetPluginID(), 1)
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 UPDATE_CHECK_INTERVAL = 60 * 60 -- Check once per hour
 local last_update_check = -1
@@ -537,6 +537,10 @@ function migrate_database()
         add_history_table(db)
     end
 
+    if current_version < 7 then
+        normalize_existing_mobs(db)
+    end
+
     InfoNote("Migration complete!")
     db:execute(string.format("PRAGMA user_version = %i;", SCHEMA_VERSION))
 
@@ -665,6 +669,67 @@ function add_mob_area_index(db)
         CREATE INDEX IF NOT EXISTS mobs_zone_mob_room ON mobs (zone, mob, room);
         CREATE INDEX IF NOT EXISTS area_key ON area (key);
     ]])
+end
+
+function normalize_existing_mobs(db)
+    -- Schema v7: strip transient flag/aura prefixes (e.g. "(flying) (red aura) ")
+    -- from stored mob names and merge the resulting duplicate (mob, roomid) rows,
+    -- summing seen_count and kill_count. The scan path used to record a mob under
+    -- whatever combat flags it happened to be wearing, fragmenting one mob into
+    -- several rows and splitting its seen/kill history. This consolidates them.
+    DebugNote("Normalizing mob names and merging flag-duplicated rows")
+    local agg = {}
+    local order = {}
+    for row in db:nrows("SELECT mob, room, roomid, zone, seen_count, kill_count FROM mobs") do
+        local norm = normalize_mob_name(row.mob)
+        local key = string.lower(norm) .. "\0" .. tostring(row.roomid)
+        local e = agg[key]
+        if not e then
+            e = {mob = norm, room = row.room, roomid = row.roomid, zone = row.zone, seen = 0, kill = 0}
+            agg[key] = e
+            table.insert(order, key)
+        end
+        e.seen = e.seen + (tonumber(row.seen_count) or 0)
+        e.kill = e.kill + (tonumber(row.kill_count) or 0)
+        -- prefer an already-clean original as the canonical display name
+        if row.mob == norm then
+            e.mob = norm
+        end
+    end
+
+    local ops = {}
+    table.insert(ops, "ALTER TABLE mobs RENAME TO old_mobs;")
+    table.insert(
+        ops,
+        [[
+			CREATE TABLE mobs (
+				mob 		TEXT NOT NULL COLLATE NOCASE,
+				room 		TEXT NOT NULL COLLATE NOCASE,
+				roomid 		INTEGER NOT NULL,
+				zone 		TEXT NOT NULL,
+				seen_count 	INTEGER NOT NULL DEFAULT 0,
+				kill_count 	INTEGER NOT NULL DEFAULT 0,
+				UNIQUE(mob, roomid));
+		]]
+    )
+    for _, key in ipairs(order) do
+        local e = agg[key]
+        table.insert(
+            ops,
+            string.format(
+                "INSERT INTO mobs (mob,room,roomid,zone,seen_count,kill_count) VALUES (%s,%s,%i,%s,%i,%i);",
+                fixsql(e.mob),
+                fixsql(e.room),
+                tonumber(e.roomid),
+                fixsql(e.zone),
+                e.seen,
+                e.kill
+            )
+        )
+    end
+    table.insert(ops, "DROP TABLE old_mobs;")
+    table.insert(ops, "CREATE INDEX IF NOT EXISTS mobs_zone_mob_room ON mobs (zone, mob, room);")
+    execute_in_transaction(db, ops)
 end
 
 function write_marks_to_db(db)
@@ -1860,6 +1925,49 @@ function save_mob_keyword_keyword(area, mob_name, keyword)
     return true
 end
 
+-- Transient mob flags/auras the game prepends to a mob's displayed name
+-- (e.g. "(flying) (red aura) a goose", "(f)(g)(w) warloxan"). These are stripped
+-- before a mob is stored or keyed, so a single mob is not recorded as several
+-- different rows depending on the spells/flags it happened to be wearing.
+-- NOTE: identity-style parentheticals (e.g. School of Horror titles like
+-- "(Helper)", "(Shogun)") are deliberately NOT listed, so they are preserved.
+NORM_MOB_FLAGS = {
+    ["flying"] = true, ["hidden"] = true, ["invis"] = true, ["invisible"] = true,
+    ["translucent"] = true, ["wounded"] = true, ["aimed"] = true, ["charmed"] = true,
+    ["animated"] = true, ["diseased"] = true, ["angry"] = true, ["marked"] = true,
+    ["opk"] = true, ["!"] = true,
+    -- short scan flag codes
+    ["f"] = true, ["g"] = true, ["r"] = true, ["w"] = true, ["i"] = true, ["t"] = true,
+    ["h"] = true, ["p"] = true, ["d"] = true, ["x"] = true, ["c"] = true, ["a"] = true,
+}
+
+function normalize_mob_name(name)
+    if not name then
+        return name
+    end
+    local s = name
+    while true do
+        local pre, inner = string.match(s, "^(%s*%(([^()]*)%)%s*)")
+        if not inner then
+            break
+        end
+        local key = string.lower(inner)
+        key = string.gsub(key, "^%s+", "")
+        key = string.gsub(key, "%s+$", "")
+        if NORM_MOB_FLAGS[key] or string.match(key, "^%a+ aura$") then
+            s = string.sub(s, #pre + 1)
+        else
+            break -- unknown parenthetical: treat as part of the name, stop stripping
+        end
+    end
+    s = string.gsub(s, "^%s+", "")
+    s = string.gsub(s, "%s+$", "")
+    if s == "" then
+        return name -- never reduce a name to nothing
+    end
+    return s
+end
+
 function gmkw(s, a) -- guess mob keywords
     if not s then
         return ""
@@ -2317,13 +2425,14 @@ end
 
 function record_target_killed(target)
     -- a mob was killed as part of a cp/gq
+    local mob = normalize_mob_name(target.mob)
     queries = {
         string.format(
             [[
 				INSERT OR IGNORE INTO mobs (mob,room,roomid,zone)
 				VALUES (%s,%s,%s,%s);
 			]],
-            fixsql(target.mob),
+            fixsql(mob),
             fixsql(current_room.name),
             tonumber(current_room.rmid),
             fixsql(current_room.arid)
@@ -2334,7 +2443,7 @@ function record_target_killed(target)
 				SET kill_count = kill_count + 1
 				WHERE mob = %s AND roomid = %i;
 			]],
-            fixsql(target.mob),
+            fixsql(mob),
             tonumber(current_room.rmid)
         )
     }
@@ -8472,7 +8581,7 @@ function rawCopyPwarDB()
                     insertStatements,
                     string.format(
                         "INSERT OR IGNORE INTO mobs (mob,room,roomid,zone,seen_count) VALUES (%s,%s,%s,%s,%i);",
-                        fixsql(mob.mob),
+                        fixsql(normalize_mob_name(mob.mob)),
                         fixsql(room.name),
                         mob.roomid,
                         fixsql(room.area),
@@ -9196,6 +9305,7 @@ function write_mob_list_to_db(mob_list)
     local writes = {}
     local sql_mobs = {}
     for i, mob in ipairs(mob_list) do
+        mob = normalize_mob_name(mob)
         table.insert(sql_mobs, fixsql(mob))
         table.insert(
             writes,


### PR DESCRIPTION
> **Note:** Builds on #127 (mob-name normalization) — it relies on `normalize_mob_name` and the consolidated per-room counts. Until #127 merges into `beta`, the diff here will also show that commit; the change specific to this PR is the second commit, "Offer all candidate rooms…". Happy to hold this until #127 lands.

## Summary
When a campaign/GQ names a mob that's been seen in several rooms of one area, SnD collapsed those rooms to a single one (highest `kill_count`, or a dedupe by room *name*) and navigated only there. If the mob isn't in that room this reset — wrong instance, it moved, or a stale count — the run stalls. This makes `xcp`/express offer **every** known room for the mob, ranked best-bet first, walkable with `go 1` / `go 2` / … / `nx`.

## Why
The canonical case is "Justice" in The Partroxis: one name, four distinct static rooms, four vnums. The DB already stores all four (per `(mob, roomid)`), but target building threw away all but one. Worse, the room-cp path deduped by room *name*, and The Partroxis has several rooms literally named "Cell" — so distinct rooms could collapse into the wrong one.

## What it does
New `search_rooms_by_mob(mob_name, arid)`:
- queries every `roomid` the mob is recorded in for the zone,
- ranks them `kill_count DESC, seen_count DESC, roomid ASC`,
- refreshes room name/area from the mapper (authoritative) and floats maze start rooms,
- feeds them all into the existing `gotoList` via `search_rooms_results` — so the established `go N` / `nx` navigation and the `(chance%)` table work unchanged.

It returns the number of candidate rooms, or 0 when the mob has never been recorded (so callers fall back).

Wired into `xcp_goto_target`:
- **express path** — list all candidate rooms, auto-`go 1` to the best, the rest reachable via `go 2..N` / `nx`; falls back to the previous direct jump if no rooms are found.
- **room-cp path** — use the mob's actual rooms; fall back to the previous `search_rooms_exact` (room-name search) only when the mob has never been recorded. The existing autonav single-result auto-go is preserved.

Because candidates are keyed by `roomid`, duplicate room *names* no longer collapse to the wrong room.

## Scope
`build_area_targets` / `build_room_targets` are unchanged — the target list still shows one line per mob. The expansion happens at navigation time, which keeps the diff small and reuses the existing nav/UI.

## Verification
- SQL validated on live `SnDdb.db`: `Justice`/Partroxis returns its 4 rooms ranked (A Whirlpool of Lava, kill 100, first at ~75% chance); a never-seen mob returns 0 → clean fallback; ordinary multi-room mobs rank as expected.
- Live-tested in-game across 40+ campaigns. I haven't tested The Partroxis specifically, but the same multi-room behaviour shows up throughout the lower-level campaigns I ran. Before this change I hit the "sent to the wrong/empty room" problem in nearly every campaign, at all levels; since the fix I haven't seen it. Single-room mobs and never-seen mobs behave as before.

## Trade-offs considered

| Aspect | Choice | Alternative / why not |
|---|---|---|
| Where to expand | At navigation (`search_rooms_by_mob`) | Thread candidate lists through `build_*_targets` — rejected: larger diff, duplicates nav logic |
| Ranking | kill → seen → roomid | Mapper proximity / nearest-first — deferred; needs distance calc, worth a follow-up |
| Express + multiple rooms | Auto-go best, keep rest selectable | Always show the list (no auto-go) — rejected: regresses express speed for the common case |
| Same-name across *areas* | Unchanged (existing area branch) | This PR targets the multi-room-single-area gap only |

Happy to reshape any of this, and fine to close without merging if it's not the direction you want for SnD.
