### PR TITLE
Add xset autonav: auto-go when xcp/qw resolves to a single room (beta)

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -205,6 +205,9 @@ local xset_vidblain_onoff = GetVariable("mcvar_xset_vidblain_onoff") or "off"
 -- [[ Extra GQ aliases ]]
 local xset_gq_check_extra_aliases = GetVariable("mcvar_xset_gq_check_extra_aliases") or "on"
 
+-- [[ Auto-navigate on single xcp/qw result ]]
+local xset_autonav_onoff = GetVariable("mcvar_xset_autonav_onoff") or "off"
+
 -- [[ Variables from old Mapper Extender ]]
 local area_range_index = {}
 local area_start_rooms = {}
@@ -3416,6 +3419,12 @@ function xcp_goto_target(index)
                     end
                 else -- Room cp:  get target room from mapper, but don't move yet.  "go" takes you to room.
                     search_rooms_exact(t.roomName, t.arid, t.mob)
+                    -- When autonav is enabled and exactly one room was found,
+                    -- go there immediately (Pwar parity). Multi-result cases
+                    -- still require manual selection.
+                    if xset_autonav_onoff == "on" and gotoList[1] and not gotoList[2] then
+                        Execute("go 1")
+                    end
                 end
             else
                 InfoNote(string.format("\nYou can't run there while you're %s!\n", character_state_string()))
@@ -3882,8 +3891,11 @@ function qw_match(name, line, wildcards)
     xg_draw_window()
     search_rooms_exact(room, current_room.arid, Trim(wildcards.mobname))
 
-    if go_after then
-        goto_number(nil, nil, {})
+    -- When autonav is enabled and exactly one room was found, go there
+    -- immediately (Pwar parity). Replaces the prior dead `go_after` branch
+    -- that was referenced but never assigned anywhere.
+    if xset_autonav_onoff == "on" and gotoList[1] and not gotoList[2] then
+        Execute("go 1")
     end
 end
 
@@ -7312,6 +7324,7 @@ function onHelp(name, line, wildcards)
 		"express",
         "xset nx",
         "xset con_overwrite",
+        "xset autonav",
         "xset gqalias",
 		"xset maze",
         "xset table notes",
@@ -7792,6 +7805,20 @@ function onHelp(name, line, wildcards)
                 {
                     helpWrap(
                         "Disable replacing the output of consider. This is mainly for when you have other plugins that replace the output."
+                    )
+                }
+            )
+        )
+    elseif str == "xset autonav" then
+        ColourNote("yellow", "", "Syntax", "antiquewhite", "", ": xset autonav")
+        Note()
+        ColourNote(
+            "antiquewhite",
+            "",
+            unpack(
+                {
+                    helpWrap(
+                        "Toggles auto-navigation after 'xcp <index>' or 'qw <mob>' when there is exactly one matching mapper room. When enabled, SnD executes 'go 1' automatically as soon as the single-row table is shown instead of waiting for you to type it. Multi-room matches still require manual selection so you don't auto-navigate into the wrong area. Off by default. Matches Pwar's SnD behaviour for users migrating from that plugin. Does not affect quest retargeting, 'xm'/'xmall', or other research commands."
                     )
                 }
             )
@@ -8823,6 +8850,12 @@ end
 
 function is_con_overwritten()
     return xset_overwrite_con == "on"
+end
+
+function xset_autonav()
+    xset_autonav_onoff = (xset_autonav_onoff == "on") and "off" or "on"
+    set_variable("mcvar_xset_autonav_onoff", xset_autonav_onoff)
+    InfoNote("\nAuto-navigate on single xcp/qw room result is now ", string.upper(xset_autonav_onoff), "\n")
 end
 
 function toggle_con_overwrite_triggers()
@@ -10301,6 +10334,8 @@ end
         <alias match="^xset nx (?<action>smartscan|con|scan|scanhere|qs|none)$" script="xset_nx" enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12"></alias>
 
         <alias match="^xset con_overwrite" script="xset_con_overwrite" enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12"></alias>
+
+        <alias match="^xset autonav$" script="xset_autonav" enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12"></alias>
 
         <alias match="^xset sound$" script="xset_sound" enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12"></alias>
 


### PR DESCRIPTION
> **Re-targeted to `beta`.** This supersedes #124 (same fix, originally opened against `master`); I'll close that one in favour of this. Re-applied on top of `origin/beta` in its compact trigger/alias style — note the beta tip is a WIP commit.

## Summary
Opt-in toggle `xset autonav` (default **off**, preserves current behaviour). When enabled, if `xcp <index>` or `qw <mob>` resolves to exactly one mapper room, SnD executes `go 1` immediately after rendering the single-row table instead of waiting for the user to type it. Matches Pwar's plugin behaviour — intended to reduce friction for users migrating from that plugin.

Closes #123.

## Why
Users migrating from Pwar's plugin expect `xcp <index>` to "just go" when there's no ambiguity. Current SnD always shows the table, even for single-row results, so the extra keystroke is pure friction for known mobs in known rooms. The current behaviour is preserved for everyone who wants the discovery-friendly table view — this PR just adds the option.

## Behaviour
- **off** (default): today's behaviour — table rendered, user types `go 1` or clicks the link.
- **on**: if the result has exactly one mapper room, `go 1` is executed automatically right after the table renders. Multi-result cases still require manual selection so the user doesn't auto-navigate into the wrong zone on common room names (e.g. "The Kitchen").

## Scope
Autonav fires in two paths, both of which converge on `search_rooms_exact`:

1. **`xcp_goto_target` room-type branch** — direct `search_rooms_exact` call for room-type CP targets.
2. **`qw_match`** — covers plain `qw <mob>`, area-type xcp (via `qw_exact` after `execute_in_area` arrival), and `ht` (via `ht_complete` → `qw_exact`).

Explicitly **not** covered: `target_quest_mob` (xqt and its automatic trigger on `comm.quest` GMCP events). That path fires on reconnect/login when an active quest is reported, so autonav there would auto-walk the player to their quest room unexpectedly. Happy to broaden in a follow-up if that turns out to be a desired behaviour.

Also out of scope: `xm`/`xmall` research commands (`search_rooms_fuzzy`, not `_exact`) — those are "show me possibilities" commands where auto-motion would be wrong.

## Implementation notes
The `qw_match` change replaces a prior dead `if go_after then goto_number(nil, nil, {}) end` branch — `go_after` was referenced but never assigned anywhere in the codebase, evidence that auto-nav was partially planned at some point. This PR wires in a real conditional.

Single-room detection uses `gotoList[1] and not gotoList[2]`. `gotoList[0]` stores the first area id, `gotoList[1]` the first room id, `gotoList[2+]` subsequent rooms. For "exactly one room", `[1]` is set and `[2]` is not.

## Verification
Live-tested in-game (courtesy of @rodarvus):
- Toggle on/off: `xset autonav` flips state, `InfoNote` confirms. ✓
- `xhelp xset autonav`: renders the new help entry. ✓
- Area-type CP with a single resolved room (e.g. `a bloated vulture` → `The southern slopes of Razor Spine Ridge` in dhalgora): after walking to area, auto-goes to the exact room. ✓
- Multi-result room name: still shows the table and waits. ✓
- Default-off regression check: with autonav off, current behaviour intact. ✓

## Trade-offs and alternatives considered

| Aspect | Choice | Alternatives |
|---|---|---|
| Setting name | `xset autonav` | `xset auto_go`, `xset autogo`, `xset autorun` |
| Default | off (preserves current behaviour) | on (matches Pwar) — rejected to avoid surprising existing users |
| Quest path inclusion | Excluded | Include — rejected because of GMCP reconnect/login auto-fire |
| Check placement | Per-caller (xcp_goto_target, qw_match) | End of `search_rooms_exact` — rejected because `target_quest_mob` shares that function |

Happy to adjust any of these if you'd prefer a different shape. And if you decide the behaviour isn't a good fit for SnD — for any reason — closing the PR without merging is completely fine.
