### PR TITLE
Fix cp/gq parse-end triggers stalling under COMPACT mode (beta)

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -9958,7 +9958,7 @@ end
             <send>	EnableTrigger("trg_gq_check_end", true) </send>
         </trigger>
 
-        <trigger match="^(?!You still have to kill [1-3] \* .+ \(\S.+?(?: - Dead)?\))$" script="gq_check_end" name="trg_gq_check_end" group="trg_gq_check" enabled="n" regexp="y" sequence="500" keep_evaluating="y" omit_from_output="n" send_to="12"></trigger>
+        <trigger match="^(?!You still have to kill [1-3] \* .+ \(\S.+?(?: - Dead)?\)).*$" script="gq_check_end" name="trg_gq_check_end" group="trg_gq_check" enabled="n" regexp="y" sequence="500" keep_evaluating="y" omit_from_output="n" send_to="12"></trigger>
 
         <!-- gq messages to always listen for -->
         <trigger match="^You have now joined Global Quest # (?<gq_id>\d{1,5})\. See 'help gquest' for available commands\.$" script="gqmsg_joined" enabled="y" regexp="y" sequence="100" keep_evaluating="y" send_to="12"></trigger>
@@ -9999,7 +9999,7 @@ end
 
         <trigger match="^Find and kill 1 \* (?<target>.+)$" script="cp_info_line" name="trg_cp_info_line" group="trg_campaign" enabled="n" regexp="y" sequence="100" keep_evaluating="y" send_to="12"></trigger>
 
-        <trigger match="^(?!Find and kill 1 \* .+ \(.+\))$" script="cp_info_end" name="trg_cp_info_end" group="trg_campaign" enabled="n" regexp="y" sequence="100" keep_evaluating="y" send_to="12">
+        <trigger match="^(?!Find and kill 1 \* .+ \(.+\)).*$" script="cp_info_end" name="trg_cp_info_end" group="trg_campaign" enabled="n" regexp="y" sequence="100" keep_evaluating="y" send_to="12">
             <send>	EnableTrigger("trg_cp_info_line", false)
 					EnableTrigger("trg_cp_info_end", false) </send>
         </trigger>
@@ -10009,7 +10009,7 @@ end
         </trigger>
 
 
-        <trigger match="^(?!You still have to kill \* .+ \(.+?(?: - Dead)?\))$" script="cp_check_end" name="trg_cp_check_end" group="trg_campaign" enabled="n" regexp="y" sequence="100" keep_evaluating="y" omit_from_output="y" send_to="12">
+        <trigger match="^(?!You still have to kill \* .+ \(.+?(?: - Dead)?\)).*$" script="cp_check_end" name="trg_cp_check_end" group="trg_campaign" enabled="n" regexp="y" sequence="100" keep_evaluating="y" omit_from_output="y" send_to="12">
             <send>	EnableTrigger("trg_cp_check_gag_dead", true)
 					EnableTrigger("trg_cp_check_line", false)
 					EnableTrigger("trg_cp_check_end", false) </send>


### PR DESCRIPTION
> **Re-targeted to `beta`.** This supersedes #126 (same fix, originally opened against `master`); I'll close that one in favour of this. Re-applied on top of `origin/beta` — note the beta tip is a WIP commit.

## Summary
Three SnD parse-end triggers (`trg_cp_info_end`, `trg_cp_check_end`, `trg_gq_check_end`) match a regex shape that in PCRE only fires on empty lines: `^(?!X)$`. Aardwolf's `COMPACT` setting (`Remove the blank line between commands`) suppresses the blank line that would normally terminate cp/gq command output, so for COMPACT-on users these triggers sit enabled until some unrelated empty line eventually arrives. Until then the corresponding parse-end function never fires, `area_room_type` stays `"none"`, and `xcp` rejects with "you're not on a cp" — even though the player IS on a cp, just with the data not yet classified.

Closes #79.

## Root cause
`^(?!X)$` is anchored start + zero-width negative lookahead + anchored end, with nothing consumed in between. In PCRE that matches only when start position equals end position — i.e. empty lines.

For non-empty lines like `Use 'cp check' to see only…`:
- `^` at position 0 ✓
- `(?!Find and kill…)` succeeds (line doesn't start with X)
- `$` requires end of line; we're at position 0; end of line is well past 0 → fails

So the trigger waits for a blank line. With COMPACT on (default off in Aardwolf, but commonly enabled), there's no blank line between command output and prompt. The trigger fires later when something unrelated produces a blank line in the stream — typically a tick (~30s), channel message, or room movement.

This was acknowledged in #79 back in 2021 as "appears to only be an issue if you do not have prompt enabled" — the actual variable turns out to be `compact`, not prompt. The pseudo-tags fix proposed at the time didn't land; Aardwolf doesn't expose tags for cp/check/gq output (`help tags` confirms).

Reproduced with `xtest debug` on, COMPACT enabled, fresh `cp request`:
```
... cp info output ...
Use 'cp check' to see only targets that you still need to kill.
[1528/1528hp ... 14qt 483tnl] Dbl: 9>
DEBUG: Changing mcvar_cp_level_taken to 37     ← cp_info_level_taken did fire
Search and Destroy: 'xcp' aborted - you're not on a cp.    ← xcp #1, area_room_type still "none"
[... same prompt ...] Dbl: 9>
Search and Destroy: 'xcp' aborted - you're not on a cp.    ← xcp #2
[... regen prompt ...] Dbl: 8>                              ← ~30s later, tick
cp type detection: area (level 37)                          ← cp_info_end FINALLY fired
```

`cp_info_level_taken` and `cp_info_line` fired correctly throughout. Only the end trigger stalled.

## Fix
Change `^(?!X)$` → `^(?!X).*$` in all three triggers. Now matches any line not starting with X — empty OR non-empty. Trigger fires on the first reasonable end-of-block line:

| Trigger | Was triggered by | Now triggered by |
|---|---|---|
| `trg_cp_info_end` | Empty line after cp info | First non-`Find and kill…` line (the trailing `---` separator) |
| `trg_cp_check_end` | Empty line after cp check | First non-`You still have to kill…` line (`Note: Dead…` if any dead, or `You have N days…`) |
| `trg_gq_check_end` | Empty line after gq check | First non-`You still have to kill N…` line |

Single-character change per regex (just adding `.*` before `$`). No code changes, no callers touched, trigger group enable/disable choreography unchanged.

## Safety
Each end trigger is only enabled by its corresponding start/line trigger firing on a kill line:
- `trg_cp_info_end` is enabled by `trg_cp_info_targets` matching `^The targets for this campaign are:$`. The next line is always a `Find and kill…` line (per Aardwolf's output), then more, then `---`. The negative lookahead excludes `Find and kill…` lines, so the new pattern fires on `---`. Can't pre-fire because the targets header doesn't exist yet when the trigger isn't enabled.
- `trg_cp_check_end` is enabled by `trg_cp_check_line` firing on the FIRST kill line. It can't fire before the kill list exists.
- `trg_gq_check_end` is enabled by `trg_gq_check_line` firing on the FIRST kill line. Same reasoning.

All three triggers still have `omit_from_output="y"` (or `omit_from_output="n"` in `trg_gq_check_end`'s case — pre-existing inconsistency unchanged here). The end-of-block line they now match will be gagged just like an empty line was — no visual difference for the user.

## Verification
Live-tested in-game (COMPACT on, level 37 character):
- **Before fix**: `cp request` → `xcp` → "aborted - you're not on a cp" → wait ~30s for unrelated blank line → eventually works.
- **After fix**: `cp request` → cp info parses immediately → `xcp` works on the first try. ✓

Also verified:
- `cp check` rebuilds after a kill no longer stall ✓
- `gq check` rebuilds work consistently ✓
- `xtest simulate cp area` exercise passes ✓
- Plugin loads with no Lua errors ✓
- Other commands (`xcp N`, `qw <mob>`, `nx`, etc.) behave unchanged ✓

## Trade-offs considered

| Approach | Why not |
|---|---|
| **Regex tweak (chosen)** | Minimum diff, no callers touched, single-char change per trigger, robustly handles both empty-line and non-empty cases |
| Aardwolf pseudo-tags (originally proposed in #79) | Verified Aardwolf doesn't have tags for cp_info/cp_check/gq_check output |
| Match a specific end-marker line (e.g. `Use 'cp check'…`) | More fragile — depends on Aardwolf's exact wording at end of each block; the regex tweak handles whatever line comes next |
| `DoAfter(2, "<rebuild>")` fallback timer | Crude, adds always-on 2s delay even when blank line would have arrived |

## Out of scope (worth noting)
The misleading `xcp` error message (`"you're not on a cp"` when actually CP data is loading) — separate small fix. With this trigger fix, the loading window shrinks to milliseconds in practice, making the misleading message a non-issue. Happy to follow up with a UX-only PR distinguishing loading-state from not-on-cp state if you'd like.
