### PR TITLE
Fix undefined plevel reference in anex_can_get_new_cp (beta)

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -4535,7 +4535,7 @@ function anex_can_get_new_cp() -- called by line 'You may take campaign this lev
             else
                 if (noexp_onoff == "on") then
                     anex_set_noexp("off")
-                    InfoNote("\nSearch and Destroy: Turning noexp OFF (you have reached level ", plevel, ")")
+                    InfoNote("\nSearch and Destroy: Turning noexp OFF (you have reached level ", level, ")")
                 end
             end
         else -- feature is turned off, just show reminder


### PR DESCRIPTION
> **Re-targeted to `beta`.** This supersedes #116 (same fix, originally opened against `master`); I'll close that one in favour of this. Re-applied on top of `origin/beta` — note the beta tip is a WIP commit.

## Summary
Single-token fix: `plevel` → `level` in `anex_can_get_new_cp`.

## Background
`anex_can_get_new_cp` references an undefined variable `plevel` when formatting the "you have reached level N" notification, so the message logs a nil where the level should be. The local `level` (from `char.status.level`) is defined at the top of the same function and is what was intended.

## Reference
The sibling branches in the same function (and `anex_must_level_new_cp`) correctly use `level`. This change brings this branch in line.

## Trigger conditions
Only fires for level-200 players with `xset noexp` active when a new campaign becomes available — narrow path, but real.
