### PR TITLE
Fix ellipsify column overflow when names are truncated (beta)

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -3267,7 +3267,7 @@ function ellipsify(str, max_length)
     if #str <= max_length then
         return str
     else
-        return str:sub(1, max_length - 1) .. "..."
+        return str:sub(1, max_length - 3) .. "..."
     end
 end
 


### PR DESCRIPTION
> **Re-targeted to `beta`, reduced patch.** This supersedes #117 (originally opened against `master`); I'll close that one in favour of this. beta already switched the truncation marker from the Unicode `…` to ASCII `...`, so this PR is just the remaining off-by-2 fix. Note the beta tip is a WIP commit.

## Summary
`ellipsify` truncates to `max_length - 1` but appends a 3-character marker, so a truncated string is `max_length + 2` characters wide and overflows its column in the campaign target table.

Closes #110.

## Root cause
```lua
return str:sub(1, max_length - 1) .. "..."
```
beta already moved from the single-glyph Unicode `…` to ASCII `...` (good — `#` and `string.format("%-Ns", …)` are byte-based, so the old 3-byte glyph also misaligned). But the truncation length stayed at `max_length - 1`, which was correct for a 1-column marker and is now 2 too long for the 3-column `...`. Result: `(max_length - 1) + 3 = max_length + 2` columns, so the `-` separator and every following column shift right by 2 on any truncated row.

This affects all `ellipsify` call sites (mob name, room name, location, notes, etc.), since they all rely on the result being exactly `max_length` wide.

## Fix
Reserve room for the full marker:
```lua
return str:sub(1, max_length - 3) .. "..."
```
Now the result is exactly `max_length` characters. No call-site changes needed — every `string.format("%-Ns", ellipsify(s, N))` keeps working.

## Verification
Live-tested in-game: a campaign table containing a long, truncated mob name now lines its columns up with the untruncated rows; short (untruncated) names are unchanged.

## Trade-offs considered

| Option | Result | Why not |
|---|---|---|
| **`max_length - 3` (chosen)** | bytes == visual == max_length; one-character diff, no caller changes | — |
| Revert to `…` and pad visually | needs a visual-width helper at all call sites | larger surface area; future callers must remember the helper |
