### PR TITLE
Scan/consider regex: add aim flag and [A-Z] catch-all (beta)

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -9404,6 +9404,7 @@ local SCAN_FLAGS = {
     "W",
     "wounded",
     "aimed",
+    "!",
     "Old",
     "O"
 }
@@ -9425,7 +9426,13 @@ local CONSIDER_OUTCOMES = {
 }
 
 function setup_scan_con_triggers()
-    local flags_string = "(?<flags>(?: ?\\[AFK\\]| ?\\((?:" .. table.concat(SCAN_FLAGS, "|") .. ")\\))*)?"
+    -- The paren group matches either a single uppercase letter (catch-all for any
+    -- current or future Aardwolf single-letter flag) or an explicit entry from
+    -- SCAN_FLAGS. Without the [A-Z] catch-all, any scan line containing a flag
+    -- not yet added to SCAN_FLAGS silently fails the regex and mobs in the line
+    -- never get their [CP]/[GQ]/[Q] activity tag. Multi-char names like "(Helper)"
+    -- remain safe because they match neither [A-Z]{1} nor the whitelist.
+    local flags_string = "(?<flags>(?: ?\\[AFK\\]| ?\\((?:[A-Z]|" .. table.concat(SCAN_FLAGS, "|") .. ")\\))*)?"
     local match = "^ {5}-" .. flags_string .. " (?<mob_name>.+)$"
     local name
 


### PR DESCRIPTION
> **Re-targeted to `beta`, reduced patch.** This supersedes #122 (originally opened against `master`); I'll close that one in favour of this. beta already expanded `SCAN_FLAGS` (it now includes `Flying`/`F` and most others), so this PR adds only what's still missing. Note the beta tip is a WIP commit.

## Summary
`scan_mob` and the `consider_*` triggers share a regex whose flag group is built from a hardcoded `SCAN_FLAGS` whitelist. When Aardwolf sends a flag character not in the whitelist, the whole regex fails to match, the trigger never fires, and the mob line flows to output without its `[CP]`/`[GQ]`/`[Q]` activity tag.

Closes #121.

## Root cause
```lua
local flags_string = "(?<flags>(?: ?\\[AFK\\]| ?\\((?:" .. table.concat(SCAN_FLAGS, "|") .. ")\\))*)?"
local match = "^ {5}-" .. flags_string .. " (?<mob_name>.+)$"
```
For a line like `     - (!)(R) a mob`, the flags group tries `(!)`; `!` isn't in the whitelist, so zero flags are consumed, the following literal space then fails against `(`, and the whole regex fails — so `scan_mob()` never runs and the activity tag is never added.

beta already added the previously-missing `Flying`/`F` and the rest of `help mobflags`, so the only canonical flag still absent is `(!)` Aimed.

PR #63 (2021) deliberately made the whitelist strict so mob-name parens like `(Helper) Fenix` aren't misparsed as flags. That constraint is right; the list just needs the aim flag, plus a guard against falling behind again.

## Fix
1. **Add the missing `"!"` (Aimed)** entry to `SCAN_FLAGS`.
2. **Add `[A-Z]` as an alternative inside the paren group**, so any future single-letter Aardwolf flag is matched without another code change. `(Helper) Fenix` stays safe — "Helper" matches neither `[A-Z]{1}` nor any whitelist entry.

End-state group: `(?: ?\[AFK\]| ?\(([A-Z]|<whitelist…>|!)\))*`

## Verification
Live-tested in-game: an aimed mob on a campaign (scan/consider line beginning `- (!)…`) now correctly receives its `[CP]`/`[GQ]` tag instead of being dropped. `(Helper)`-style names and AFK-bracketed players render as before (no regression).

## Trade-offs considered

| Option | Result | Why not |
|---|---|---|
| **`"!"` + `[A-Z]` catch-all (chosen)** | fixes the aim flag now + future-proofs against new single-letter flags; whitelist stays as documentation | slightly more surface to review |
| `"!"` only | minimal diff | regresses again next time Aardwolf adds a letter |
| Permissive `\([^)]+\)` | simplest | re-breaks `(Helper) Fenix`, which #63 specifically guarded |

Happy to drop the `[A-Z]` broadening and keep it to `"!"` alone if you'd prefer the whitelist strict.
