### PR TITLE
Keyword generator: cut at first apostrophe/hyphen instead of truncating across it

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -1916,20 +1916,56 @@ function gmkw(s, a) -- guess mob keywords
     else
         s3 = s2
     end
-    s3 = string.gsub(s3, "-", " ")
-
     local s4 = {}
     for w in string.gmatch(s3, "[^ ]+") do
         table.insert(s4, w)
     end
-    local len1 = #(s4[1])
-    local len2 = #(s4[#s4]) or 0
+
+    -- Aardwolf keeps "'" and "-" as literal characters in a mob's keyword and
+    -- matches keyword PREFIXES. A keyword that is truncated mid-punctuation
+    -- (e.g. "nulan'b" from "Nulan'Boar") or that fuses/splits a hyphenated word
+    -- ("yama uba" / "yamauba" from "yama-uba") does not match. Reduce each chosen
+    -- word to the clean segment BEFORE its first apostrophe/hyphen, which is
+    -- always a valid prefix of the full token, before truncating it. This
+    -- replaces the old blanket "s3 = gsub(-, ' ')", which only worked for the
+    -- subset of hyphenated mobs whose keyword happens to split on the hyphen.
+    local function punct_safe(w)
+        if not (string.find(w, "'", 1, true) or string.find(w, "-", 1, true)) then
+            return w
+        end
+        local seg = string.match(w, "^[^'%-]*")
+        if seg and #seg >= 3 then
+            return seg
+        end
+        -- Leading segment too short (e.g. "'cal", "o'", "t-rex"): fall back to
+        -- the segment after the first punctuation.
+        local after = string.match(w, "^[^'%-]*['%-](.*)$") or ""
+        local alt = string.match(after, "^[^'%-]*") or ""
+        if #alt >= 3 then
+            return alt
+        end
+        if seg and #seg > 0 then
+            return seg
+        elseif #alt > 0 then
+            return alt
+        end
+        local stripped = string.gsub(w, "['%-]", "")
+        return stripped
+    end
+
     if (#s4 > 1) then -- mob name has multiple words
+        local first = punct_safe(s4[1])
+        local last = punct_safe(s4[#s4])
         local x, y = math.random(4, 6), math.random(4, 6)
-        guess = string.sub(s4[1], 1, x) .. " " .. string.sub(s4[#s4], 1, y)
+        guess = string.sub(first, 1, x) .. " " .. string.sub(last, 1, y)
     elseif (#s4 == 1) then -- mob name has one word
-        local x = math.random(2 + round_banker(len1 * 0.5), len1)
-        guess = string.sub(s4[1], 1, x)
+        local only = punct_safe(s4[1])
+        local len1 = #only
+        -- Clamp the lower bound so the random range is never empty (min > max),
+        -- which errors for short segments such as "rex" (from "T-Rex").
+        local lo = math.min(2 + round_banker(len1 * 0.5), len1)
+        local x = math.random(lo, len1)
+        guess = string.sub(only, 1, x)
     else -- Sometimes all of the mob words get deleted, if so just use original input.  In theory, if we reached this step
         guess = s or "gmkw error in stage 4" -- then the input is non-nil and I've never seen it be "" ... so, if it errors it means Lua is propagating a nil
     end


### PR DESCRIPTION
## Summary
`gmkw` (the auto keyword generator) truncates a mob's first/last word to a few characters. When a word contains an apostrophe or hyphen, this produced keywords Aardwolf can't match:
- a cut mid-punctuation leaves a dangling apostrophe — `nulan'b` from `a Nulan'Boar mother`, `rauko'` from `Rauko'mool` — which Aardwolf rejects;
- the old blanket `s3 = string.gsub(s3, "-", " ")` turned a hyphenated word into two tokens — `yama uba` from `a yama-uba` — where the second token prefix-matches nothing on the mob.

This reduces each chosen word to the clean segment **before** its first apostrophe/hyphen, then truncates that. Aardwolf keeps `'` and `-` as literal keyword characters and matches keyword **prefixes**, so the leading segment is always a valid prefix of the real token.

## Background
This supersedes #119 (closed). That attempt tried the opposite rule — *keep the whole punctuated word* — which fixed `Nulan'Boar` but regressed other mobs: it over-fit one case. Checking the human-curated `mob_keyword_exceptions` across two large live databases showed why no "always keep" or "always split" rule can work:
- **Apostrophe mobs:** the curated working keyword *drops or splits* the apostrophe ~85% of the time (`Rauko'mool`→`mool`, `Gale's pet rabbit`→`rabbit`, `Dak'Tai's shaman`→`dak shaman`). `Nulan'Boar` (keep) is the outlier.
- **Hyphen mobs:** roughly a 50/50 split between keep (`yama-uba`, `half-griffon`) and drop/split (`buck-toothed`→`buck`, `sand-blasted skeleton`→`skeleton`, `axe-wielding warrior`→`warrior`).

The clean **leading prefix** is the one transform that's valid for *both* camps, because Aardwolf prefix-matches: `yama-uba`→`yama` ✓ (keep-class) and `buck-toothed`→`buck` ✓ (split-class) both target correctly.

## Fix
A small `punct_safe(w)` helper in `gmkw`:
- if the word has no `'`/`-`, return it unchanged (non-punctuated mobs are completely unaffected);
- otherwise take the segment before the first `'`/`-`;
- guard: if that leading segment is too short (e.g. `'cal`, `o'`, `t-rex`), fall back to the segment *after* the first punctuation (`t-rex`→`rex`).

Applied to the first and last chosen words before the existing 4–6 char truncation. Removes the old hyphen→space line. Also clamps the single-word random range (`math.min(2 + round_banker(len1*0.5), len1)`) so a short segment can't produce `min > max` and error.

## Verification
A faithful mirror of `gmkw` was run over **609 punctuated mob names** from two live SnD databases, comparing the current beta code, the closed #119, and this fix:

| | dangling-punctuation keywords (the failure mode) |
|---|---|
| current beta | 16 / 609 (2.6%) |
| closed #119 | 4 / 609 (0.7%) |
| **this PR** | **0 / 609 (0.0%)** |

Per-mob examples (current → this PR): `Rauko'mool` `rauko'`→`rauko`; `Miad'Bir` `miad'`→`miad`; `Fal'Shara` `fal'sh`→`fal`; `a yama-uba` `yama uba`→`yama`; `the buck-toothed lizard-man` keeps a clean `buck …`. Where a curated working keyword exists, the generated prefix is consistent with it. Live-tested in-game across a spread of keep/split/possessive/leading-apostrophe/multi-punctuation cases.

I'd frame the win precisely: this **eliminates the punctuation-truncation failure mode** for punctuated mobs (0 dangling keywords vs 16 on current beta), with **no change to non-punctuated mobs**. It does not try to reproduce every hand-curated keyword exactly — that's what the exceptions table is for — only to stop generating keywords that can't match.

## Known, unrelated limitation (server-side)
Even with a correct keyword, Aardwolf can mis-disambiguate same-family mobs: in a room with `a Nulan'Boar mother`, `a Nulan'Boar girl`, and `a Nulan'Boar baby`, `kill nulan'boar baby` may target the mother. Reproducible without the plugin; nothing the keyword side can fix. Flagging so the limit is clear.

## Trade-offs considered

| Option | Why not |
|---|---|
| **Leading clean segment (chosen)** | — |
| Keep the whole punctuated word (the closed #119) | over-fits; regresses the ~85% of apostrophe mobs whose keyword drops the apostrophe |
| Always split on hyphen (current beta) | wrong for ~half of hyphen mobs whose keyword keeps the hyphen (yama-uba, half-griffon) |
| Strip punctuation entirely (`yamauba`) | Aardwolf rejects the fused form |

Happy to adjust the short-segment guard threshold or anything else.
